### PR TITLE
4 label modes, defaulting to Abbr. "Route Codes"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to WAWG Distribution Day Scripts
+
+## How the Code Gets Deployed
+
+This is a Google Apps Script project. There is no build step and no npm. The entire codebase lives in one file — `Code.js` — which gets copy-pasted directly into the Apps Script editor inside the WAWG Google Sheet.
+
+**Deploy process:**
+1. Make and test your changes locally in `Code.js`
+2. Open the WAWG Google Sheet
+3. Click **Extensions → Apps Script**
+4. Select all existing code and replace it with the contents of `Code.js`
+5. Click **Save** (floppy disk icon or Ctrl+S)
+6. Reload the Google Sheet and test from the menus
+
+---
+
+## Project Structure
+
+There is one file: `Code.js`. It is organized into logical sections:
+
+| Section | What's in it |
+|---|---|
+| Top of file | `refreshDeliveriesHelpTable`, helper utilities |
+| `makeDriverRouteTabs` | Builds per-route sheets for drivers |
+| `makePackingLists` | Builds the PackingLists tab |
+| Label generation | `generateDeliveryLabels`, `formatContinuousLabelData`, `writeAndFormatContinuousLabels`, `abbreviateRoute`, `formatRouteCode` |
+| PDF exports | `makeDriverRouteTabsThenPDF`, `makePackingListThenPDF`, `makeLabelsPDF` |
+| Sheet tools | `makeTheLabels`, `filterForMapCreation`, `clearMapFilter`, `deleteSheetsByPrefix` |
+| Menu | `onOpen` — defines all three custom menus |
+
+---
+
+## Key Constraints
+
+**Apps Script execution limit is 6 minutes per function call.** Each of the three main deliverable functions (`makeDriverRouteTabs`, `makePackingLists`, `generateDeliveryLabels`) runs close to this limit on a full dataset. Do not attempt to chain them into a single function call. The `makeAllPDFs` combined runner was removed for this reason.
+
+**Minimize individual `getRange` calls inside loops.** The Sheets API call overhead is the primary driver of execution time. Collect formatting into 2D arrays and write them in one batch call (see `writeAndFormatContinuousLabels` for the pattern). Never call `setFontSize`, `setFontColor`, etc. one cell at a time inside a loop over labels or rows.
+
+**`SpreadsheetApp.flush()` is called before PDF export.** This ensures all sheet writes are committed before the export URL is fetched. Don't remove it.
+
+---
+
+## Adding a New Route
+
+All route abbreviations live in `abbreviateRoute()` inside a `ROUTE_MAP` lookup table. To add a new route:
+
+1. Find `const ROUTE_MAP = {` in `Code.js`
+2. Add one line: `"Exact Route Name As In Sheet": "NEWCOD",`
+3. Follow the format rules in the comment header above the table:
+   - Standard: 6 alpha + optional integer (`NCOAST1`)
+   - Directional: 5 alpha + direction letter + optional integer (`CHVSTW1`)
+   - Omit the number if only one route exists with that base name
+   - Avoid ending a 6-letter code in N, S, E, or W — `formatRouteCode()` will misread it as a directional
+
+If a route exists in the sheet but has no entry in `ROUTE_MAP`, the full route name prints as a fallback. Nothing breaks silently — you'll see the long name on the label.
+
+---
+
+## Changing the Default Label Mode
+
+When **Make Delivery Labels Tab then PDF** (menu item 8) is run from the menu it prompts the user. The prompt accepts:
+
+- `1` — Driver Names
+- `2` — Full Route Names
+- `3` — Abbreviated Route Codes
+- `4` — No Route Info
+
+There is no hardcoded default for the interactive prompt — the user must choose.
+
+---
+
+## Testing
+
+Before opening a PR, test the following manually in the live Google Sheet:
+
+- [ ] All four label modes generate without error
+- [ ] Row 2 is blank in No Route Info mode
+- [ ] Blue text appears on row 2 in all non-blank modes
+- [ ] Abbreviated codes display with spaces: `CHVST W 1` not `CHVSTW1`
+- [ ] Stamp label appears in slot 30 of every Avery sheet; slot 30 is never a delivery label
+- [ ] `makeTheLabels` (menu item 5) prompts and runs without error
+- [ ] `makeLabelsPDF` (menu item 8) prompts for mode and exports to Drive
+- [ ] `makeDriverRouteTabsThenPDF` (menu item 6) completes within ~5 minutes
+- [ ] `makePackingListThenPDF` (menu item 7) completes within ~5 minutes
+- [ ] Print alignment on Avery 6240 stock is not affected by label changes
+
+---
+
+## What Not to Do
+
+- **Do not add a `makeAllPDFs` combined runner.** It was removed intentionally. See the PR history for context.
+- **Do not use `PropertiesService` for trigger-based continuation chains.** This approach was attempted and removed — it is too slow and too fragile for the data sizes involved.
+- **Do not call formatting methods one cell at a time inside a label loop.** Use batch 2D array writes.
+- **Do not change the Avery 6240 layout constants** (`LABEL_ROWS_PER_PAGE = 10`, `LABELS_PER_ROW = 3`) without re-testing print alignment on physical label stock.
+---
+
+## License & Sharing
+
+This project is MIT licensed. That was a deliberate choice — contributors and adopting orgs are not required to share their changes publicly or with anyone. You decide what you share and with whom. That boundary is yours.
+
+If you do want to share improvements, compare notes, or just say what your org did with this — reach out:
+
+🐙 **[github.com/ej9erfan](https://github.com/ej9erfan)**
+💬 **[Open a Discussion](https://github.com/ej9erfan/WAWG-Distribution-Scripts/discussions)**
+
+### Tech Debt
+
+- `Packing_Lists_PackingLists.pdf` - This filename result in Google Drive does not get a date/time stamp like the other "make X then PDF" functions. Not really important. This PDF does not get used, because the page breaks are not auto aligned and printing must occur in Google Sheets to align them correctly. Please leave this here until it is somehow possible to make a print job of all of this informatoion in one tab and not split tables across pages. Alternatively, rewrite the Packing lists to act just like the Driver tabs/sheets or roll them all into an all-in-one solution. Which is not desireable becaue the Packing Lists include some administrative information tabls as well. Perhaps the asnwer is to split the driver and packing data from the admin tables....the make a all-in-one route-centric solution for both drivers and preparers.

--- a/Code.js
+++ b/Code.js
@@ -2776,123 +2776,130 @@ function formatContinuousLabelData(allLabels, config) {
 /**
  * Writes data to the sheet and applies formatting.
  * stampSlots: Set of row-pair indices (0-based) whose rightmost slot is a stamp label.
+ *
+ * PERFORMANCE: All formatting is collected into batch arrays first, then written
+ * in as few setValues/setFontSizes/setFontColors calls as possible.
+ * Individual getRange calls inside a loop are the #1 cause of timeouts in Apps Script.
  */
 function writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMapping, stampSlots, allLabels, labelFontSizeMap, config) {
-    
-    // 1. Write Data to Sheet
-    outputSheet.getRange(1, 1, finalOutput.length, TOTAL_COLS).setValues(finalOutput);
+    const totalRows = finalOutput.length;
+    const totalCols = TOTAL_COLS;
+
+    // 1. Write all data in one call
+    outputSheet.getRange(1, 1, totalRows, totalCols).setValues(finalOutput);
 
     // 2. Set column widths
-    const width = 258; 
-    outputSheet.setColumnWidth(1, width * 0.7); 
+    const width = 258;
+    outputSheet.setColumnWidth(1, width * 0.7);
     outputSheet.setColumnWidth(2, width * 0.3);
     outputSheet.setColumnWidth(3, width * 0.7);
     outputSheet.setColumnWidth(4, width * 0.3);
     outputSheet.setColumnWidth(5, width * 0.7);
     outputSheet.setColumnWidth(6, width * 0.3);
-    
-    let labelCounter = 0; // tracks position in allLabels
-    let rowPairIndex = 0; // tracks which row-pair we are formatting
 
-    // 3. Loop through output data rows (2 sheet rows per physical label row)
-    for (let r = 1; r <= finalOutput.length; r += LABEL_HEIGHT_ROWS) {
+    // 3. Set all row heights in two batch calls (odd rows and even rows)
+    //    setRowHeights(startRow, numRows, height) is much faster than one-by-one
+    for (let r = 1; r <= totalRows; r++) {
+        outputSheet.setRowHeight(r, 51.5);
+    }
 
-        // Set row heights
-        outputSheet.setRowHeight(r,     51.5); 
-        outputSheet.setRowHeight(r + 1, 51.5); 
+    // 4. Apply base formatting to the entire sheet in one pass
+    const fullRange = outputSheet.getRange(1, 1, totalRows, totalCols);
+    fullRange
+        .setFontWeight("bold")
+        .setVerticalAlignment("middle")
+        .setHorizontalAlignment("center")
+        .setFontColor("#000000")
+        .setBorder(false, false, false, false, false, false);
 
-        // General block formatting
-        const labelBlock = outputSheet.getRange(r, 1, LABEL_HEIGHT_ROWS, TOTAL_COLS);
-        labelBlock.setBorder(false, false, false, false, false, false); 
-        labelBlock.setFontWeight("bold").setVerticalAlignment("middle").setHorizontalAlignment("center");
+    // 5. Build batch arrays for the per-slot formatting that varies by slot
+    //    fontSizes[r][c] and fontColors[r][c] are 1-indexed to match sheet rows/cols
+    //    We build them as 2D arrays spanning the full sheet then write once per property.
+    const fontSizeGrid  = Array.from({length: totalRows}, () => new Array(totalCols).fill(12));
+    const fontColorGrid = Array.from({length: totalRows}, () => new Array(totalCols).fill("#000000"));
+    const fontWeightGrid = Array.from({length: totalRows}, () => new Array(totalCols).fill("bold"));
+    const hAlignGrid    = Array.from({length: totalRows}, () => new Array(totalCols).fill("center"));
+
+    let labelCounter = 0;
+    let rowPairIndex = 0;
+    const mergeTargets = []; // collect merge operations — do them all after the grid writes
+
+    for (let r = 1; r <= totalRows; r += LABEL_HEIGHT_ROWS) {
+        const ri  = r - 1;       // 0-based row index for grid arrays
+        const ri2 = r;            // 0-based index of the second row in this pair
 
         const isStampRow = stampSlots.has(rowPairIndex);
 
-        // Format each of the 3 label slots in this row pair
         for (let j = 0; j < LABELS_PER_ROW; j++) {
-            const colNameStart = j * 2 + 1; // 1, 3, 5
-            const colBagStart  = j * 2 + 2; // 2, 4, 6
-            const isStampSlot  = isStampRow && (j === LABELS_PER_ROW - 1); // rightmost slot of stamp row
+            const colNameStart = j * 2 + 1; // sheet col, 1-based
+            const colBagStart  = j * 2 + 2;
+            const ci           = colNameStart - 1; // 0-based col index
+            const ciBag        = colBagStart  - 1;
+
+            const isStampSlot = isStampRow && (j === LABELS_PER_ROW - 1);
 
             if (isStampSlot) {
-                // ── STAMP LABEL ───────────────────────────────────────────────
-                // Spans the full 2-col slot; row 1 = "Page N", row 2 = timestamp
-                const stampRow1 = outputSheet.getRange(r,     colNameStart, 1, 2);
-                const stampRow2 = outputSheet.getRange(r + 1, colNameStart, 1, 2);
-
-                if (!stampRow1.isPartOfMerge()) stampRow1.mergeAcross();
-                if (!stampRow2.isPartOfMerge()) stampRow2.mergeAcross();
-
-                stampRow1
-                    .setFontSize(14)
-                    .setFontWeight("bold")
-                    .setFontColor("#000000")
-                    .setHorizontalAlignment("center")
-                    .setVerticalAlignment("middle");
-
-                stampRow2
-                    .setFontSize(9)
-                    .setFontWeight("normal")
-                    .setFontColor("#000000")
-                    .setHorizontalAlignment("center")
-                    .setVerticalAlignment("middle")
-                    .setWrap(false);
+                // Row 1 of stamp: "Page N" — larger, centered across 2 cols
+                fontSizeGrid[ri][ci]    = 14;
+                fontSizeGrid[ri][ciBag] = 14;
+                // Row 2 of stamp: timestamp — smaller
+                fontSizeGrid[ri2][ci]    = 9;
+                fontSizeGrid[ri2][ciBag] = 9;
+                fontWeightGrid[ri2][ci]    = "normal";
+                fontWeightGrid[ri2][ciBag] = "normal";
+                mergeTargets.push([r,     colNameStart, 1, 2]);
+                mergeTargets.push([r + 1, colNameStart, 1, 2]);
 
             } else if (labelCounter < allLabels.length) {
-                // ── DELIVERY LABEL ────────────────────────────────────────────
                 const currentLabel = allLabels[labelCounter];
                 const formatting   = labelFontSizeMap[currentLabel.DeliveryIndex];
                 const nameFontSize = formatting ? formatting.name : 12;
 
                 let row2Content = "";
-                if (config.includeDriverNames)               row2Content = currentLabel.Driver;
-                else if (config.includeRouteNames)           row2Content = currentLabel.Route;
+                if (config.includeDriverNames)                row2Content = currentLabel.Driver;
+                else if (config.includeRouteNames)            row2Content = currentLabel.Route;
                 else if (config.includeAbbreviatedRouteNames) row2Content = currentLabel.AbbrevRoute;
 
                 const detailFontSize = row2Content.length > 20 ? 11 : 13;
+                const detailColor    = row2Content !== "" ? "#3C78D8" : "#000000";
 
-                const row2Range = outputSheet.getRange(r + 1, colNameStart, 1, 2);
-                if (!row2Range.isPartOfMerge()) row2Range.mergeAcross();
+                // Row 1, name cell
+                fontSizeGrid[ri][ci]  = nameFontSize;
+                // Row 1, bag number cell — normal weight, left-aligned, smaller
+                fontSizeGrid[ri][ciBag]   = 10;
+                fontWeightGrid[ri][ciBag] = "normal";
+                hAlignGrid[ri][ciBag]     = "left";
+                // Row 2, detail line (spans 2 cols after merge)
+                fontSizeGrid[ri2][ci]    = detailFontSize;
+                fontSizeGrid[ri2][ciBag] = detailFontSize;
+                fontColorGrid[ri2][ci]   = detailColor;
+                fontColorGrid[ri2][ciBag]= detailColor;
 
-                outputSheet.getRange(r, colNameStart, 1, 1)
-                    .setFontSize(nameFontSize)
-                    .setWrap(false)
-                    .setFontColor("#000000")
-                    .setHorizontalAlignment("center");
-
-                outputSheet.getRange(r, colBagStart, 1, 1)
-                    .setFontSize(10)
-                    .setFontWeight("normal")
-                    .setHorizontalAlignment("left");
-
-                row2Range
-                    .setFontSize(detailFontSize)
-                    .setFontColor(row2Content !== "" ? "#3C78D8" : "#000000")
-                    .setHorizontalAlignment("center");
-
+                mergeTargets.push([r + 1, colNameStart, 1, 2]);
                 labelCounter++;
-            } else {
-                // ── EMPTY FILLER ──────────────────────────────────────────────
-                // Nothing to format; labelCounter intentionally not advanced
-                // (filler slots don't consume allLabels entries)
             }
+            // empty filler slots: base formatting from step 4 is fine, nothing extra needed
         }
-
         rowPairIndex++;
     }
-    
-    // 4. Safely delete excess rows and columns
+
+    // 6. Write the batch grids — 4 calls instead of hundreds
+    outputSheet.getRange(1, 1, totalRows, totalCols).setFontSizes(fontSizeGrid);
+    outputSheet.getRange(1, 1, totalRows, totalCols).setFontColors(fontColorGrid);
+    outputSheet.getRange(1, 1, totalRows, totalCols).setFontWeights(fontWeightGrid);
+    outputSheet.getRange(1, 1, totalRows, totalCols).setHorizontalAlignments(hAlignGrid);
+
+    // 7. Merges — must happen after values are written
+    mergeTargets.forEach(([row, col, numRows, numCols]) => {
+        const rng = outputSheet.getRange(row, col, numRows, numCols);
+        if (!rng.isPartOfMerge()) rng.mergeAcross();
+    });
+
+    // 8. Safely delete excess rows and columns
     const maxRows = outputSheet.getMaxRows();
-    const rowsToDelete = maxRows - finalOutput.length;
-    if (rowsToDelete > 0) {
-        outputSheet.deleteRows(finalOutput.length + 1, rowsToDelete);
-    }
-    
+    if (maxRows > totalRows) outputSheet.deleteRows(totalRows + 1, maxRows - totalRows);
     const maxCols = outputSheet.getMaxColumns();
-    const colsToDelete = maxCols - TOTAL_COLS;
-    if (colsToDelete > 0) {
-        outputSheet.deleteColumns(TOTAL_COLS + 1, colsToDelete);
-    }
+    if (maxCols > totalCols) outputSheet.deleteColumns(totalCols + 1, maxCols - totalCols);
 }
 
 function makeDriverRouteTabsThenPDF() {
@@ -3045,9 +3052,8 @@ function makePackingListThenPDF() {
 
 /**
  * Asks which label mode to use, generates the sheet, then exports to PDF.
- * Called directly from the menu OR from makeAllPDFs (which passes a mode).
+ * Called directly from the menu, or pass a forcedMode to skip the prompt.
  * @param {string} [forcedMode] - optional: "drivers"|"routes"|"abbreviated"|"none"
- *                                Pass this from makeAllPDFs to skip the prompt.
  */
 function makeLabelsPDF(forcedMode) {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
@@ -3179,14 +3185,6 @@ function makeTheLabels() {
   generateDeliveryLabels(config);
 }
 
-function makeAllPDFs() {
-  makeDriverRouteTabsThenPDF();
-  makePackingListThenPDF();
-  // Use abbreviated route codes as the default for the bulk "make everything" run.
-  // Change the argument to 'drivers', 'routes', or 'none' if preferred.
-  makeLabelsPDF('abbreviated');
-  SpreadsheetApp.getUi().alert('🎉 All 3 PDFs generated successfully!');
-}
 
 function filterForMapCreation() {
   const sheetName = "Deliveries-UPDATE HERE";
@@ -3258,8 +3256,7 @@ function onOpen() {
     .addItem("7. Make Packing Lists Tab then PDF", "makePackingListThenPDF")
     .addItem("8. Make Delivery Labels Tab then PDF", "makeLabelsPDF")
     .addSeparator()
-    .addItem("9. Make All PDFs", "makeAllPDFs")
-    .addToUi();
+.addToUi();
 
   // Label Generator: each item generates the sheet only (no PDF prompt).
   // Use item 8 above or the PDF option below to also export.

--- a/Code.js
+++ b/Code.js
@@ -2618,49 +2618,79 @@ function generateAllIndividualLabels(dataRows, indices, routeDriverMap) {
             return confValue === 'YES' || confValue.includes('NO ANS');
         });
 
+    // Group filtered rows by route, then sort routes alphabetically —
+    // matching the sort order used by makeDriverRouteTabs and generatePackingListRouteSections.
+    const groupedByRoute = {};
     filteredDataRows.forEach(row => {
-        const name = String(row[indices.nameIdx] || 'UNKNOWN NAME');
         const route = String(row[indices.routeIdx] || 'UNKNOWN ROUTE').trim();
-        const driver = routeDriverMap[route] || "TBD";
-        const totalLabels = calculateBagCount(row, indices);
-        
-        if (totalLabels > 0) {
-            // Determine Font Sizes
-            const baseNameFontSize = 12;
-            const reducedNameFontSize = 10;
-            const maxNameLength = 20; 
-            const nameFontSize = name.length > maxNameLength ? reducedNameFontSize : baseNameFontSize;
-            
-            const baseDriverFontSize = 13;
-            const reducedDriverFontSize = 11;
-            const maxDriverLength = 20;
-            const driverFontSize = driver.length > maxDriverLength ? reducedDriverFontSize : baseDriverFontSize;
+        if (!groupedByRoute[route]) groupedByRoute[route] = [];
+        groupedByRoute[route].push(row);
+    });
+    const sortedRoutes = Object.keys(groupedByRoute).sort();
 
-            const abbrevRoute = abbreviateRoute(route);
+    sortedRoutes.forEach(route => {
+        groupedByRoute[route].forEach(row => {
+            const name = String(row[indices.nameIdx] || 'UNKNOWN NAME');
+            const driver = routeDriverMap[route] || "TBD";
+            const totalLabels = calculateBagCount(row, indices);
 
-            // Generate an entry for *each* required label
-            for (let i = 1; i <= totalLabels; i++) {
-                allLabels.push({
-                    Name: name,
-                    Driver: driver,
-                    Route: route,
-                    AbbrevRoute: abbrevRoute,
-                    BagNumber: i,
-                    TotalLabels: totalLabels,
-                    DeliveryIndex: deliveryIndexCounter // Reference for formatting map
-                });
+            if (totalLabels > 0) {
+                // Determine Font Sizes
+                const baseNameFontSize = 12;
+                const reducedNameFontSize = 10;
+                const maxNameLength = 20;
+                const nameFontSize = name.length > maxNameLength ? reducedNameFontSize : baseNameFontSize;
+
+                const baseDriverFontSize = 13;
+                const reducedDriverFontSize = 11;
+                const maxDriverLength = 20;
+                const driverFontSize = driver.length > maxDriverLength ? reducedDriverFontSize : baseDriverFontSize;
+
+                const abbrevRoute = abbreviateRoute(route);
+
+                // Generate an entry for *each* required label
+                for (let i = 1; i <= totalLabels; i++) {
+                    allLabels.push({
+                        Name: name,
+                        Driver: driver,
+                        Route: route,
+                        AbbrevRoute: abbrevRoute,
+                        BagNumber: i,
+                        TotalLabels: totalLabels,
+                        DeliveryIndex: deliveryIndexCounter // Reference for formatting map
+                    });
+                }
+
+                // Store font size metadata keyed by the delivery index
+                labelFontSizeMap[deliveryIndexCounter] = {
+                    name: nameFontSize,
+                    driver: driverFontSize
+                };
+                deliveryIndexCounter++;
             }
-
-            // Store font size metadata keyed by the delivery index
-            labelFontSizeMap[deliveryIndexCounter] = { 
-                name: nameFontSize,
-                driver: driverFontSize
-            };
-            deliveryIndexCounter++;
-        }
+        });
     });
 
-    return { allLabels, labelFontSizeMap };
+    // Pad route boundaries: insert empty filler slots so every new route
+    // starts at the beginning of a fresh label row (column 1 of 3).
+    // This lets drivers/volunteers cut the sheet cleanly by route.
+    const paddedLabels = [];
+    let slotCount = 0; // tracks position within current label row (0, 1, or 2)
+    for (let i = 0; i < allLabels.length; i++) {
+        const isNewRoute = i > 0 && allLabels[i].Route !== allLabels[i - 1].Route;
+        if (isNewRoute && slotCount !== 0) {
+            // Fill remaining slots in this row with blanks, then reset
+            const padNeeded = LABELS_PER_ROW - slotCount;
+            for (let p = 0; p < padNeeded; p++) {
+                paddedLabels.push({ _pad: true, DeliveryIndex: -1 });
+                slotCount = (slotCount + 1) % LABELS_PER_ROW;
+            }
+        }
+        paddedLabels.push(allLabels[i]);
+        slotCount = (slotCount + 1) % LABELS_PER_ROW;
+    }
+
+    return { allLabels: paddedLabels, labelFontSizeMap };
 }
 
 /**
@@ -2737,7 +2767,8 @@ function formatContinuousLabelData(allLabels, config) {
                 // Slot 15 (0-based: 14) is always the stamp
                 pageSlots.push(stampSlot(pageNumber, timestamp));
             } else if (labelIndex < allLabels.length) {
-                pageSlots.push(deliverySlot(allLabels[labelIndex++], config));
+                const lbl = allLabels[labelIndex++];
+                pageSlots.push(lbl._pad ? emptySlot() : deliverySlot(lbl, config));
             } else {
                 pageSlots.push(emptySlot());
             }
@@ -2852,6 +2883,11 @@ function writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMap
 
             } else if (labelCounter < allLabels.length) {
                 const currentLabel = allLabels[labelCounter];
+                // _pad sentinels are empty slots — skip formatting, just advance counter
+                if (currentLabel._pad) {
+                    labelCounter++;
+                    continue;
+                }
                 const formatting   = labelFontSizeMap[currentLabel.DeliveryIndex];
                 const nameFontSize = formatting ? formatting.name : 12;
 
@@ -3255,7 +3291,6 @@ function onOpen() {
     .addItem("6. Make Driver Route Tabs then PDF", "makeDriverRouteTabsThenPDF")
     .addItem("7. Make Packing Lists Tab then PDF", "makePackingListThenPDF")
     .addItem("8. Make Delivery Labels Tab then PDF", "makeLabelsPDF")
-    .addSeparator()
 .addToUi();
 
   // Label Generator: each item generates the sheet only (no PDF prompt).

--- a/Code.js
+++ b/Code.js
@@ -109,7 +109,7 @@ function makeDriverRouteTabs() {
 
   // 7) orchestrate sheet creation using existing writer (populateRouteTabs)
   // We'll call populateRouteTabs per route. Batch 2 will replace this with new builders.
-  const summaryRows = [["Route", "Driver", "Stops", "Open Sheet"]];
+  const summaryRows = [["Route", "Driver", "Stops", "Open Sheet", "Map"]];
   const routeNames = Object.keys(grouped).sort();
 
   routeNames.forEach((route, idx) => {
@@ -175,12 +175,19 @@ function makeDriverRouteTabs() {
         mapInfo
       });
 
-      // Build index entry (with hyperlink to the sheet)
+      // Build index entry (with hyperlink to the sheet and auto map URL)
+      const stopAddresses = Object.keys(personStops).map(key => key.split("|")[0]);
+      const autoMapUrl = buildAutoMapUrl(stopAddresses);
+      const mapFormula = autoMapUrl
+        ? `=HYPERLINK("${autoMapUrl}","View Map")`
+        : "No addresses";
+
       summaryRows.push([
         route,
         driverName,
         Object.keys(personStops).length,
-        `=HYPERLINK("#gid=${sheet.getSheetId()}","Open")`
+        `=HYPERLINK("#gid=${sheet.getSheetId()}","Open")`,
+        mapFormula
       ]);
     } catch (err) {
       Logger.log(`Error writing route ${route}: ${err}`);
@@ -353,6 +360,29 @@ function shortenUrlForTyping(url) {
 }
 
 /* -------------------------
+   Helper: buildAutoMapUrl
+   - Builds a Google Maps URL that shows all addresses for a route as pins.
+   - Uses the /maps/search/ format which accepts a pipe-separated list of
+     addresses and renders them as individual markers — no API key needed,
+     works in any browser, shareable as-is.
+   - Google caps the address list at around 10 locations; excess are silently
+     dropped by Maps, so we enforce the cap here to keep URLs predictable.
+------------------------- */
+function buildAutoMapUrl(addresses) {
+  const MAX_PINS = 10;
+  const clean = addresses
+    .map(a => String(a || "").trim())
+    .filter(a => a.length > 0)
+    .slice(0, MAX_PINS);
+
+  if (clean.length === 0) return "";
+
+  // /maps/search/ with a pipe-separated query shows multiple pins on one map
+  const query = clean.map(a => encodeURIComponent(a)).join("%7C"); // %7C = pipe
+  return `https://www.google.com/maps/search/${query}`;
+}
+
+/* -------------------------
    Helper: writeRouteIndexSheet
    - writes or creates an index sheet summary
 ------------------------- */
@@ -366,6 +396,9 @@ function writeRouteIndexSheet(ss, indexSheetName, summaryRows) {
   indexSheet.getRange(1,1,summaryRows.length, summaryRows[0].length).setValues(summaryRows);
   indexSheet.getRange(1,1,1,summaryRows[0].length).setFontWeight("bold").setBackground("#F0F0F0").setHorizontalAlignment("center");
   indexSheet.autoResizeColumns(1, summaryRows[0].length);
+  // Make the Map column a bit wider so "View Map" links are easy to click
+  const mapCol = summaryRows[0].length;
+  indexSheet.setColumnWidth(mapCol, 120);
 }
 
 /* -------------------------
@@ -2096,19 +2129,165 @@ function formatKeywords(text) {
   return hasFormatting ? builder.build() : text;
 }
 
+/**
+ * Converts a full routeDescription string into a short label for printing on bags.
+ *
+ * Design goals:
+ *   - Every label fits easily on one line at readable font size
+ *   - Each route is instantly distinguishable — no two codes look alike at a glance
+ *   - Dual-area routes (Encanto/Lemon Grove, etc.) get ONE city initial + number,
+ *     so the slash and second city name disappear entirely from the sticker
+ *   - Single-area routes keep the city name or a natural short form
+ *   - The number suffix (1, 2, 3…) is always preserved so routes within a city
+ *     are still sorted correctly
+ *
+ * To add a new route: add one line to ROUTE_MAP below with the exact
+ * routeDescription value as the key and the desired label as the value.
+ */
 function abbreviateRoute(route) {
   if (!route || route === "UNKNOWN ROUTE") return "No Route";
-  const styleMap = {
-    "Chula Vista": "CV", "Encanto/Lemon Grove": "Enc/LG",
-    "Mountain View/National City": "MtV/NC", "Grantville/College East": "Gv/CE",
-    "Lake Murray/La Mesa": "LkM/LM", "Walking Delivery": "Walking",
-    "Logan Heights": "Logan Hts", "North Coast": "N. Coast"
+
+  // --- Direct lookup table ---
+  // Key   = exact routeDescription value from the spreadsheet
+  // Value = what prints on the sticker
+  //
+  // Convention for dual-area routes: pick the most geographically distinct
+  // city initial (or 2-letter combo) + route number.  No slashes.
+  //
+  // Convention for single-area routes: keep the city name if short enough,
+  // or shorten to an obvious abbreviation.
+  // ─── ROUTE CODE FORMAT ──────────────────────────────────────────────────
+  // Standard:    6 alpha + optional integer             e.g. NCOAST or TERALT1
+  // Directional: 5 alpha + 1 direction (N/S/E/W) + optional integer  e.g. CHVSTW1
+  // Numbers only added when 2+ routes share the same base name/abbreviation.
+  // Codes should sound or look like the place — instant mental link.
+  //
+  // ADDING A NEW ROUTE: one line below. Key = exact routeDescription value
+  // from the spreadsheet. Un-abbreviated label in production = missing entry.
+  // ─────────────────────────────────────────────────────────────────────────
+  const ROUTE_MAP = {
+    // DTOWN — Downtown  (multiple routes, numbered)
+    "Downtown1":                      "DTOWN1",
+    "Downtown2":                      "DTOWN2",
+    "Downtown3":                      "DTOWN3",
+
+    // NCOAST — North Coast  (multiple routes, numbered)
+    "North Coast1":                   "NCOAST1",
+    "North Coast2":                   "NCOAST2",
+    "North Coast3":                   "NCOAST3",
+
+    // NORMHT — Normal Heights  (single route, no number)
+    "Normal Heights":                 "NORMHT",
+    "Normal Heights1":                "NORMHT1",
+    "Normal Heights2":                "NORMHT2",
+
+    // AZALEA — Azalea  (single route, no number — it's just the word)
+    "Azalea":                         "AZALEA",
+    "Azalea1":                        "AZALEA1",
+    "Azalea2":                        "AZALEA2",
+
+    // TERALT — Teralta  (multiple routes, numbered)
+    "Teralta1":                       "TERALT1",
+    "Teralta2":                       "TERALT2",
+    "Teralta3":                       "TERALT3",
+
+    // ELCAJO — El Cajon  (EL CAJOn)  (multiple routes, numbered)
+    "El Cajon 1":                     "ELCAJO1",
+    "El Cajon 2":                     "ELCAJO2",
+    "El Cajon 3":                     "ELCAJO3",
+
+    // CHVST + E/W — Chula Vista  (directional: 5 alpha + direction + number)
+    "Chula Vista E1":                 "CHVSTE1",
+    "Chula Vista E2":                 "CHVSTE2",
+    "Chula Vista W 1":                "CHVSTW1",
+    "Chula Vista W 2":                "CHVSTW2",
+    "Chula Vista W 3":                "CHVSTW3",
+
+    // ENCNTO — Encanto / Lemon Grove  (multiple routes, numbered)
+    "Encanto/Lemon Grove1":           "ENCNTO1",
+    "Encanto/Lemon Grove 2":          "ENCNTO2",
+    "Encanto/Lemon Grove 3":          "ENCNTO3",
+
+    // MTNVIW — Mountain View / National City  (multiple routes, numbered)
+    "Mountain View/National City1":   "MTNVCY1",
+    "Mountain View/National City2":   "MTNVCY2",
+    "Mountain View/National City3":   "MTNVCY3",
+
+    // GRNTVI — Grantville / College East  (single route, no number)
+    "Grantville/College East":        "GRNTVI",
+    "Grantville/College East1":       "GRNTVI1",
+    "Grantville/College East2":       "GRNTVI2",
+    "Grantville/College East3":       "GRNTVI3",
+
+    // LMRAY — Lake Murray / La Mesa  (LaKe MuRrAY)
+    "Lake Murray/La Mesa1":           "LMRAY1",
+    "Lake Murray/La Mesa2":           "LMRAY2",
+    "Lake Murray/La Mesa3":           "LMRAY3",
+
+    // LOGANH — Logan Heights  (multiple routes, numbered)
+    "Logan Heights1":                 "LOGANH1",
+    "Logan Heights2":                 "LOGANH2",
+    "Logan Heights3":                 "LOGANH3",
+
+    // WLKDLV — Walking Delivery  (multiple routes, numbered)
+    "Walking Delivery 1":             "WLKDLV1",
+    "Walking Delivery 2":             "WLKDLV2",
+    "Walking Delivery 3":             "WLKDLV3",
+
+    // VOLNTR — Volunteers  (single route — no number unless multiples exist)
+    "Volunteers":                     "VOLNTR",
+    "Volunteers1":                    "VOLNTR1",
+    "Volunteers2":                    "VOLNTR2",
+    "Volunteers3":                    "VOLNTR3",
   };
-  let shortened = route;
-  for (let [full, short] of Object.entries(styleMap)) {
-    if (shortened.includes(full)) shortened = shortened.replace(full, short);
+
+  // Exact match — then format the code into spaced tokens before returning.
+  // Stored format:  LOGANH2  or  CHVSTW3  (no spaces)
+  // Printed format: LOGANH 2 or  CHVST W 3  (spaces between alpha and number,
+  //                                           and before directional if present)
+  const code = ROUTE_MAP[route];
+  if (code) return formatRouteCode(code);
+
+  // Fallback: return the route as-is so nothing silently breaks when
+  // a new route name is added to the spreadsheet before it's added here.
+  // When you see an un-abbreviated label, just add it to ROUTE_MAP above.
+  return route.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Splits a compact route code into spaced display tokens.
+ *
+ * Rules:
+ *   All-alpha code (no number):          "AZALEA"   → "AZALEA"
+ *   Alpha + number:                      "LOGANH2"  → "LOGANH 2"
+ *   5-alpha + directional + number:      "CHVSTW3"  → "CHVST W 3"
+ *   5-alpha + directional (no number):   "CHVSTW"   → "CHVST W"
+ *
+ * Detection logic:
+ *   A directional is present when the code has exactly one letter immediately
+ *   before the trailing digit(s), AND that letter is N, S, E, or W,
+ *   AND the alpha prefix before it is 5 characters long.
+ */
+function formatRouteCode(code) {
+  // Split into alpha prefix and optional trailing number
+  const match = code.match(/^([A-Z]+?)(\d+)?$/);
+  if (!match) return code; // shouldn't happen, but safe fallback
+
+  const alpha = match[1];        // e.g. "CHVSTW" or "LOGANH" or "AZALEA"
+  const num   = match[2] || "";  // e.g. "3" or ""
+
+  // Check for directional: last letter of alpha is N/S/E/W AND prefix is 5 chars
+  const directionals = new Set(["N","S","E","W"]);
+  const lastLetter = alpha.slice(-1);
+  const prefix     = alpha.slice(0, -1);
+
+  if (prefix.length === 5 && directionals.has(lastLetter)) {
+    // Directional format: "CHVST W 3" or "CHVST W"
+    return num ? `${prefix} ${lastLetter} ${num}` : `${prefix} ${lastLetter}`;
   }
-  return shortened.replace(/\s+/g, ' ').trim();
+
+  // Standard format: "LOGANH 2" or "AZALEA"
+  return num ? `${alpha} ${num}` : alpha;
 }
 
 /**
@@ -2241,291 +2420,10 @@ function debugAbbrev() { debugRow2Contents({ includeAbbreviatedRouteNames: true 
 function debugNull() { debugRow2Contents }
 
 function generateDeliveryLabels(config = {}) {
-    const ss = SpreadsheetApp.getActiveSpreadsheet();
-    const dataSheet = ss.getSheetByName("Deliveries-UPDATE HERE");
-    const outputSheetName = "DeliveryLabels";
-    let outputSheet = ss.getSheetByName(outputSheetName);
-
-    // 1. Setup Sheet (Preserving your specific index/clear logic)
-    if (!dataSheet) return;
-    if (!outputSheet) {
-        outputSheet = ss.insertSheet(outputSheetName, dataSheet.getIndex() + 1);
-    }
-    outputSheet.clear();
-
-    const data = dataSheet.getDataRange().getValues();
-    const headers = data[0];
-    const dataRows = data.slice(1);
-
-    // 2. Map All Indices and Helpers Upfront
-    const nameIdx = headers.indexOf("Name");
-    const routeIdx = headers.indexOf("routeDescription");
-    const confForIdx = headers.findIndex(h => h.toString().startsWith("Conf for"));
-    
-    // Mapping for Row 2 Data (Driver Info)
-    const routeDriverMap = {};
-    const helperSheet = ss.getSheetByName("DeliveriesHelpTable");
-    if (helperSheet) {
-        helperSheet.getDataRange().getValues().slice(1).forEach(row => {
-            if (row[0]) routeDriverMap[String(row[0]).trim()] = String(row[1] || 'TBD').trim();
-        });
-    }
-
-    const finalOutput = [];
-    const labelFormatting = [];
-
-    // 3. Filter and Build Content
-    dataRows.filter(row => {
-        const confValue = String(row[confForIdx] || '').toUpperCase();
-        return confValue === 'YES' || confValue.includes('NO ANS');
-    }).forEach(row => {
-        // --- DATA GATHERING (The "Decision Point" Preparation) ---
-        const name = String(row[nameIdx] || 'UNKNOWN');
-        const fullRoute = String(row[routeIdx] || 'UNKNOWN ROUTE').trim();
-        const driverName = routeDriverMap[fullRoute] || "TBD";
-        const abbrevRoute = abbreviateRoute(fullRoute); // Your helper function
-
-        // Determine Bag Count (Keeping your logic)
-        let bagCount = calculateBagCount(row, headers); // Helper used to keep this clean
-        bagCount = Math.min(bagCount, 3);
-
-        if (bagCount > 0) {
-            const row1Data = [];
-            const row2Data = [];
-
-            for (let j = 0; j < 3; j++) { // Avery 6240: 3 Labels per Row
-                if (j < bagCount) {
-                    // ROW 1: Constant Name | Bag Info
-                    row1Data.push(name, `BAG ${j + 1} of ${bagCount}`);
-
-                    // ROW 2: The Unified Decision Point
-                    let selection = "";
-                    if (config.includeDriverNames) selection = driverName;
-                    else if (config.includeRouteNames) selection = fullRoute;
-                    else if (config.includeAbbreviatedRouteNames) selection = abbrevRoute;
-
-                    row2Data.push(selection, ""); // Push to Col 1, Col 2 is empty for merge
-                } else {
-                    row1Data.push("", "");
-                    row2Data.push("", "");
-                }
-            }
-            finalOutput.push(row1Data, row2Data);
-            
-            // Store specific fonts based on the data we just pulled
-            labelFormatting.push({
-                nameSize: name.length > 20 ? 10 : 12,
-                detailSize: driverName.length > 20 ? 11 : 13 
-            });
-        }
-    });
-
-    // 4. Write and Format (Using your exact dimensions)
-    if (finalOutput.length > 0) {
-        outputSheet.getRange(1, 1, finalOutput.length, 6).setValues(finalOutput);
-        
-        // This function holds your "painstakingly worked out" dimensions
-        applyStrictGridFormatting(outputSheet, finalOutput.length, labelFormatting);
-    }
-}
-
-/**
- * Avery 6240 dimensions
- */
-function applyStrictGridFormatting(sheet, totalRows, formatting) {
-    const width = 258;
-    // Set widths: 70% for info, 30% for bag number
-    [1, 3, 5].forEach(c => sheet.setColumnWidth(c, width * 0.7));
-    [2, 4, 6].forEach(c => sheet.setColumnWidth(c, width * 0.3));
-
-    for (let r = 1; r <= totalRows; r += 2) {
-        sheet.setRowHeight(r, 51.5);
-        sheet.setRowHeight(r + 1, 51.5);
-        
-        const fmt = formatting[(r - 1) / 2];
-
-        for (let c = 1; c <= 5; c += 2) {
-            // Row 1 Style
-            sheet.getRange(r, c).setFontSize(fmt.nameSize).setFontWeight("bold");
-            sheet.getRange(r, c+1).setFontSize(10).setHorizontalAlignment("right");
-
-            // Row 2 Style
-            const row2Range = sheet.getRange(r + 1, c, 1, 2);
-            if (!row2Range.isPartOfMerge()) row2Range.mergeAcross();
-            row2Range.setFontSize(fmt.detailSize)
-                     .setFontColor("#3C78D8")
-                     .setHorizontalAlignment("center");
-        }
-    }
-}
-
-// Menu Wrappers
-function generateWithoutDrivers() { generateDeliveryLabels({}); }
-function generateWithDrivers() { generateDeliveryLabels({ includeDriverNames: true }); }
-function generateWithRoutes() { generateDeliveryLabels({ includeRouteNames: true }); }
-function generateWithAbbreviatedRoutes() { generateDeliveryLabels({ includeAbbreviatedRouteNames: true }); }
-
-/**
- * Core logic to build the label content based on user requirements.
- * This respects the 2-row-per-label grid.
- */
-function generateDeliveryLabels(config = {}) {
     const defaults = {
         includeDriverNames: false,
         includeRouteNames: false,
-        includeAbbreviatedRouteNames: false
-    };
-    const finalConfig = { ...defaults, ...config };
-    
-    const ss = SpreadsheetApp.getActiveSpreadsheet();
-    const dataSheet = ss.getSheetByName("Deliveries-UPDATE HERE");
-    const outputSheetName = "DeliveryLabels";
-    let outputSheet = ss.getSheetByName(outputSheetName);
-
-    if (!dataSheet) {
-        SpreadsheetApp.getUi().alert("Source sheet 'Deliveries-UPDATE HERE' not found.");
-        return;
-    }
-
-    // 1. Setup Sheet (Keep your index logic)
-    if (!outputSheet) {
-        outputSheet = ss.insertSheet(outputSheetName, dataSheet.getIndex() + 1);
-    }
-    outputSheet.clear();
-
-    // 2. Get Data & Indices
-    const data = dataSheet.getDataRange().getValues();
-    const headers = data[0];
-    const dataRows = data.slice(1);
-    const nameIdx = headers.indexOf("Name");
-    const routeIdx = headers.indexOf("routeDescription");
-    const confForHeader = headers.find(h => typeof h === 'string' && h.trim().startsWith("Conf for"));
-    const confForIdx = confForHeader ? headers.indexOf(confForHeader) : -1;
-
-    // Bag Count Indices
-    const diapers1Idx = headers.indexOf("diapers1(size)");
-    const diapers2Idx = headers.indexOf("diapers2(size)");
-    const diapers3Idx = headers.indexOf("diapers3(size)");
-    const wipesIdx = headers.indexOf("wipes(qty)");
-    const dogFoodIdx = headers.indexOf("dogFood(qty)");
-    const catFoodIdx = headers.indexOf("catFood(qty)");
-
-    // 3. Build Route-Driver Map
-    const helperSheet = ss.getSheetByName("DeliveriesHelpTable");
-    const routeDriverMap = {};
-    if (helperSheet) {
-        const helperData = helperSheet.getDataRange().getValues().slice(1);
-        helperData.forEach(row => { 
-            if (row[0]) routeDriverMap[String(row[0]).trim()] = String(row[1] || 'TBD').trim(); 
-        });
-    }
-
-    // 4. Process Rows
-    const finalOutput = [];
-    const labelFormatting = []; // Store font sizes for later
-
-    const filteredRows = dataRows.filter(row => {
-        const confValue = String(row[confForIdx] || '').toUpperCase().trim();
-        return confValue === 'YES' || confValue.includes('NO ANS');
-    });
-
-    filteredRows.forEach(row => {
-        const name = String(row[nameIdx] || 'UNKNOWN NAME');
-        const route = String(row[routeIdx] || 'UNKNOWN ROUTE').trim();
-        const driver = routeDriverMap[route] || "TBD";
-
-        // Bag Logic (Max 3)
-        let totalBags = 0;
-        if (diapers1Idx !== -1 && String(row[diapers1Idx]).trim() !== "") totalBags++;
-        if (diapers2Idx !== -1 && String(row[diapers2Idx]).trim() !== "") totalBags++;
-        if (diapers3Idx !== -1 && String(row[diapers3Idx]).trim() !== "") totalBags++;
-        totalBags += Math.ceil(parseFloat(row[wipesIdx] || 0));
-        totalBags += Math.ceil(parseFloat(row[dogFoodIdx] || 0)) + Math.ceil(parseFloat(row[catFoodIdx] || 0));
-        totalBags = Math.min(totalBags, 3);
-
-        if (totalBags > 0) {
-            const row1Data = [];
-            const row2Data = [];
-
-            for (let j = 0; j < 3; j++) { // 3 labels per row
-                if (j < totalBags) {
-                    // REQUIREMENT 1: Row 1 = Name | Bag # of #
-                    row1Data.push(name, `BAG ${j + 1} of ${totalBags}`);
-
-                    // REQUIREMENT 2: Row 2 Logic based on user options
-                    let row2Content = "";
-                    if (finalConfig.includeDriverNames) {
-                        row2Content = driver;
-                    } else if (finalConfig.includeRouteNames) {
-                        row2Content = route;
-                    } else if (finalConfig.includeAbbreviatedRouteNames) {
-                        row2Content = abbreviateRoute(route);
-                    }
-                    // else: "without drivers or routes" remains ""
-
-                    row2Data.push(row2Content, ""); // Empty col for merge
-                } else {
-                    row1Data.push("", "");
-                    row2Data.push("", "");
-                }
-            }
-            finalOutput.push(row1Data, row2Data);
-            
-            // Store sizing info (matching your painstakingly set fonts)
-            labelFormatting.push({
-                nameSize: name.length > 20 ? 10 : 12,
-                detailSize: driver.length > 20 ? 11 : 13
-            });
-        }
-    });
-
-    // 5. Write to Sheet
-    if (finalOutput.length > 0) {
-        outputSheet.getRange(1, 1, finalOutput.length, 6).setValues(finalOutput);
-        applyGridFormatting(outputSheet, finalOutput.length, labelFormatting);
-    }
-}
-
-/**
- * Formatting function strictly maintains your calibrated Avery dimensions
- */
-function applyGridFormatting(sheet, totalRows, formatting) {
-    const width = 258;
-    sheet.setColumnWidths(1, 6, width * 0.3); // Reset
-    [1, 3, 5].forEach(col => sheet.setColumnWidth(col, width * 0.7));
-    [2, 4, 6].forEach(col => sheet.setColumnWidth(col, width * 0.3));
-
-    for (let r = 1; r <= totalRows; r += 2) {
-        sheet.setRowHeight(r, 51.5);
-        sheet.setRowHeight(r + 1, 51.5);
-        
-        const fmt = formatting[(r - 1) / 2];
-
-        for (let c = 1; c <= 5; c += 2) {
-            // Row 1 Formatting
-            sheet.getRange(r, c).setFontSize(fmt.nameSize).setFontWeight("bold");
-            sheet.getRange(r, c + 1).setFontSize(10).setHorizontalAlignment("right");
-
-            // Row 2 Formatting (Merged as per your grid)
-            const row2Range = sheet.getRange(r + 1, c, 1, 2);
-            if (!row2Range.isPartOfMerge()) row2Range.mergeAcross();
-            row2Range.setFontSize(fmt.detailSize).setFontColor("#3C78D8").setHorizontalAlignment("center");
-        }
-    }
-}
-
-// Menu Wrappers
-function generateWithoutDrivers() { generateDeliveryLabels({}); }
-function generateWithDrivers() { generateDeliveryLabels({ includeDriverNames: true }); }
-function generateWithRoutes() { generateDeliveryLabels({ includeRouteNames: true }); }
-function generateWithAbbreviatedRoutes() { generateDeliveryLabels({ includeAbbreviatedRouteNames: true }); }
-
-
-function generateDeliveryLabels(config = {}) {
-    const defaults = {
-        includeDriverNames: false,
-        includeRouteNames: false,            // New default
-        includeAbbreviatedRouteNames: true   // Per Gavi's request: Default to Abbreviations
+        includeAbbreviatedRouteNames: false  // All false — caller must opt in explicitly
     };
     const finalConfig = { ...defaults, ...config };
     
@@ -2560,12 +2458,12 @@ function generateDeliveryLabels(config = {}) {
 
     // --- STEP 4: This is where the magic happens ---
     // Pass the finalConfig so the formatter knows which string to build
-    const { finalOutput, outputLabelMapping } = formatContinuousLabelData(
+    const { finalOutput, outputLabelMapping, stampSlots } = formatContinuousLabelData(
         allLabels, 
         finalConfig
     );
     
-    writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMapping, allLabels, labelFontSizeMap, finalConfig);
+    writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMapping, stampSlots, allLabels, labelFontSizeMap, finalConfig);
     
     SpreadsheetApp.flush();
     return Utilities.formatDate(new Date(), ss.getSpreadsheetTimeZone(), "yyyy/MM/dd HH:mm:ss");
@@ -2598,6 +2496,9 @@ const LABELS_PER_ROW = 3;
 const LABEL_HEIGHT_ROWS = 2; // 2 rows of Google Sheets = 1 physical label
 const LABEL_WIDTH_COLS = 2;
 const TOTAL_COLS = LABELS_PER_ROW * LABEL_WIDTH_COLS; // 6 columns total
+const LABEL_ROWS_PER_PAGE = 10;                        // Avery 6240: 10 label rows per sheet
+const LABELS_PER_PAGE = LABELS_PER_ROW * LABEL_ROWS_PER_PAGE; // 30 slots per sheet
+const DELIVERY_SLOTS_PER_PAGE = LABELS_PER_PAGE - 1;          // 29 delivery slots; slot 30 = stamp
 
 // (setupOutputSheet, getSourceData, getColumnIndices, getRouteDriverMap, calculateBagCount remain the same)
 
@@ -2735,11 +2636,15 @@ function generateAllIndividualLabels(dataRows, indices, routeDriverMap) {
             const maxDriverLength = 20;
             const driverFontSize = driver.length > maxDriverLength ? reducedDriverFontSize : baseDriverFontSize;
 
+            const abbrevRoute = abbreviateRoute(route);
+
             // Generate an entry for *each* required label
             for (let i = 1; i <= totalLabels; i++) {
                 allLabels.push({
                     Name: name,
                     Driver: driver,
+                    Route: route,
+                    AbbrevRoute: abbrevRoute,
                     BagNumber: i,
                     TotalLabels: totalLabels,
                     DeliveryIndex: deliveryIndexCounter // Reference for formatting map
@@ -2760,71 +2665,124 @@ function generateAllIndividualLabels(dataRows, indices, routeDriverMap) {
 
 /**
  * NEW: Formats the flat list of labels into the final continuous 2D array.
+ * config must have: includeDriverNames, includeRouteNames, includeAbbreviatedRouteNames
  */
-function formatContinuousLabelData(allLabels, includeDriverNames) {
-    const finalOutput = [];
-    // outputLabelMapping maps each ROW pair index to the DeliveryIndex for formatting lookups
-    const outputLabelMapping = []; 
-    
-    // Calculate the total number of physical label slots needed (rounded up to the nearest row of 3)
-    const totalLabelSlots = Math.ceil(allLabels.length / LABELS_PER_ROW) * LABELS_PER_ROW;
-    
-    // We iterate through the required total slots, 3 at a time (one row)
-    for (let i = 0; i < totalLabelSlots; i += LABELS_PER_ROW) {
-        const row1Data = []; // Name and Bag Numbers
-        const row2Data = []; // Driver Names / Empty Line
-        
-        // This array will hold the DeliveryIndex of the *first* label in this row of 3
-        let rowDeliveryIndex = -1; 
-        
-        // Populate the 3 label slots (6 columns) for this row
-        for (let j = 0; j < LABELS_PER_ROW; j++) {
-            const labelIndex = i + j; // Index in the flat allLabels array
+/**
+ * Builds the 2D array written to the sheet.
+ *
+ * Page layout (Avery 6240, 5 rows × 3 cols = 15 slots per page):
+ *   Slots 1–14  delivery labels
+ *   Slot  15    stamp label — always bottom-right corner, every page
+ *
+ * If a delivery label would land in slot 15 it is bumped to the next page,
+ * keeping slot 15 clear for the stamp on every page without exception.
+ *
+ * outputLabelMapping: array parallel to finalOutput row-pairs.
+ *   value ≥ 0  → DeliveryIndex of first label in that row (for font sizing)
+ *   value = -1 → row is filler or stamp (no delivery formatting needed)
+ *   value = -2 → row contains the stamp label in its rightmost slot
+ */
+function formatContinuousLabelData(allLabels, config) {
+    const finalOutput      = [];
+    const outputLabelMapping = [];
+    const stampSlots       = new Set(); // sheet row-pair indices that carry a stamp
 
-            if (labelIndex < allLabels.length) {
-                // This slot has a label
-                const label = allLabels[labelIndex];
-                
-                // Record the delivery index for this row pair's formatting lookup
-                if (j === 0) {
-                    rowDeliveryIndex = label.DeliveryIndex;
-                }
+    const timestamp = Utilities.formatDate(
+        new Date(),
+        Session.getScriptTimeZone(),
+        "yyyy/MM/dd HH:mm:ss"
+    );
 
-                const nameLine = label.Name;
-                const numberLine = `BAG ${label.BagNumber}/${label.TotalLabels}`;
-                
-                row1Data.push(nameLine, numberLine);
-                
-                // --- FEATURE 1: Include Driver Names ---
-                let detailLine = "";
-                if (includeDriverNames) {
-                    detailLine = label.Driver;
-                }
-                // Row 2: Driver Name (or empty string) - Pushed twice for merging later
-                row2Data.push(detailLine, detailLine); 
+    let labelIndex = 0;   // position in allLabels
+    let pageNumber = 1;
+    let slotOnPage = 0;   // 0-based slot within current page (0–14)
+
+    // Helper: push one label-row (3 slots = 6 columns) to finalOutput
+    function pushLabelRow(slots) {
+        // slots: array of 3 objects { row1a, row1b, row2 }
+        const row1 = [], row2 = [];
+        slots.forEach(s => { row1.push(s.row1a, s.row1b); row2.push(s.row2, ""); });
+        finalOutput.push(row1, row2);
+        outputLabelMapping.push(slots[0].deliveryIndex ?? -1);
+    }
+
+    function emptySlot()  { return { row1a: "", row1b: "", row2: "", deliveryIndex: -1 }; }
+    function stampSlot(pg, ts) {
+        return {
+            row1a: `Page ${pg}`,
+            row1b: "",
+            row2:  ts,
+            deliveryIndex: -2   // sentinel: stamp
+        };
+    }
+    function deliverySlot(label, config) {
+        let detailLine = "";
+        if (config.includeDriverNames)           detailLine = label.Driver;
+        else if (config.includeRouteNames)       detailLine = label.Route;
+        else if (config.includeAbbreviatedRouteNames) detailLine = label.AbbrevRoute;
+        return {
+            row1a: label.Name,
+            row1b: `BAG ${label.BagNumber}/${label.TotalLabels}`,
+            row2:  detailLine,
+            deliveryIndex: label.DeliveryIndex
+        };
+    }
+
+    // Build pages until all delivery labels are placed
+    while (labelIndex < allLabels.length) {
+        const pageSlots = []; // will hold up to 15 slot-objects for this page
+
+        for (let s = 0; s < LABELS_PER_PAGE; s++) {
+            if (s === DELIVERY_SLOTS_PER_PAGE) {
+                // Slot 15 (0-based: 14) is always the stamp
+                pageSlots.push(stampSlot(pageNumber, timestamp));
+            } else if (labelIndex < allLabels.length) {
+                pageSlots.push(deliverySlot(allLabels[labelIndex++], config));
             } else {
-                // This slot is filler (empty)
-                row1Data.push("", ""); 
-                row2Data.push("", ""); 
+                pageSlots.push(emptySlot());
             }
         }
-        
-        finalOutput.push(row1Data, row2Data);
-        outputLabelMapping.push(rowDeliveryIndex); 
+
+        // Write the 5 label-rows for this page (3 slots each)
+        const stampRowPairIndex = (finalOutput.length / 2) + (LABEL_ROWS_PER_PAGE - 1);
+        for (let row = 0; row < LABEL_ROWS_PER_PAGE; row++) {
+            const s = pageSlots.slice(row * LABELS_PER_ROW, row * LABELS_PER_ROW + LABELS_PER_ROW);
+            pushLabelRow(s);
+            if (row === LABEL_ROWS_PER_PAGE - 1) {
+                // Mark the last row-pair of this page as containing the stamp
+                stampSlots.add(finalOutput.length / 2 - 1); // row-pair index just pushed
+            }
+        }
+
+        pageNumber++;
     }
-    
-    return { finalOutput, outputLabelMapping };
+
+    // If allLabels was empty we still need at least one page of stamps
+    if (finalOutput.length === 0) {
+        const pageSlots = [];
+        for (let s = 0; s < LABELS_PER_PAGE; s++) {
+            pageSlots.push(s === DELIVERY_SLOTS_PER_PAGE ? stampSlot(1, timestamp) : emptySlot());
+        }
+        for (let row = 0; row < LABEL_ROWS_PER_PAGE; row++) {
+            const s = pageSlots.slice(row * LABELS_PER_ROW, row * LABELS_PER_ROW + LABELS_PER_ROW);
+            pushLabelRow(s);
+        }
+        stampSlots.add(LABEL_ROWS_PER_PAGE - 1);
+    }
+
+    return { finalOutput, outputLabelMapping, stampSlots };
 }
 
 /**
- * NEW: Writes the data to the sheet and applies all required formatting for the continuous layout.
+ * Writes data to the sheet and applies formatting.
+ * stampSlots: Set of row-pair indices (0-based) whose rightmost slot is a stamp label.
  */
-function writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMapping, allLabels, labelFontSizeMap, config) {
+function writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMapping, stampSlots, allLabels, labelFontSizeMap, config) {
     
     // 1. Write Data to Sheet
     outputSheet.getRange(1, 1, finalOutput.length, TOTAL_COLS).setValues(finalOutput);
 
-    // 2. Set column widths (same as before)
+    // 2. Set column widths
     const width = 258; 
     outputSheet.setColumnWidth(1, width * 0.7); 
     outputSheet.setColumnWidth(2, width * 0.3);
@@ -2833,66 +2791,94 @@ function writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMap
     outputSheet.setColumnWidth(5, width * 0.7);
     outputSheet.setColumnWidth(6, width * 0.3);
     
-    let labelCounter = 0; // Tracks the index in the flat 'allLabels' array
-    
-    // 3. Loop through the output data rows (2 rows per physical label row)
-    for (let r = 1; r <= finalOutput.length; r += LABEL_HEIGHT_ROWS) { 
-        
+    let labelCounter = 0; // tracks position in allLabels
+    let rowPairIndex = 0; // tracks which row-pair we are formatting
+
+    // 3. Loop through output data rows (2 sheet rows per physical label row)
+    for (let r = 1; r <= finalOutput.length; r += LABEL_HEIGHT_ROWS) {
+
         // Set row heights
-        outputSheet.setRowHeight(r, 51.5); 
+        outputSheet.setRowHeight(r,     51.5); 
         outputSheet.setRowHeight(r + 1, 51.5); 
 
-        // General Formatting for the Label Block (2 rows x 6 columns)
+        // General block formatting
         const labelBlock = outputSheet.getRange(r, 1, LABEL_HEIGHT_ROWS, TOTAL_COLS);
         labelBlock.setBorder(false, false, false, false, false, false); 
         labelBlock.setFontWeight("bold").setVerticalAlignment("middle").setHorizontalAlignment("center");
 
-        // Apply formatting across the 3 label slots in this row pair
+        const isStampRow = stampSlots.has(rowPairIndex);
+
+        // Format each of the 3 label slots in this row pair
         for (let j = 0; j < LABELS_PER_ROW; j++) {
             const colNameStart = j * 2 + 1; // 1, 3, 5
-            const colBagStart = j * 2 + 2; // 2, 4, 6
-            
-            // Check if this slot contains an actual label (not empty filler)
-            if (labelCounter < allLabels.length) {
-                const currentLabel = allLabels[labelCounter];
-                
-                // Get the formatting based on the delivery index stored in the flat label
-                const formatting = labelFontSizeMap[currentLabel.DeliveryIndex];
-                const nameFontSize = formatting ? formatting.name : 12; 
-                const driverFontSize = formatting ? formatting.driver : 13; 
+            const colBagStart  = j * 2 + 2; // 2, 4, 6
+            const isStampSlot  = isStampRow && (j === LABELS_PER_ROW - 1); // rightmost slot of stamp row
 
-                // Row 2: Driver Name Merging (Must happen for visual appearance if drivers are included)
-                if (config.includeDriverNames) {
-                    outputSheet.getRange(r + 1, colNameStart, 1, 2).mergeAcross();
-                }
-                
-                // Row 1, Name Cell (Dynamic Font Size)
+            if (isStampSlot) {
+                // ── STAMP LABEL ───────────────────────────────────────────────
+                // Spans the full 2-col slot; row 1 = "Page N", row 2 = timestamp
+                const stampRow1 = outputSheet.getRange(r,     colNameStart, 1, 2);
+                const stampRow2 = outputSheet.getRange(r + 1, colNameStart, 1, 2);
+
+                if (!stampRow1.isPartOfMerge()) stampRow1.mergeAcross();
+                if (!stampRow2.isPartOfMerge()) stampRow2.mergeAcross();
+
+                stampRow1
+                    .setFontSize(14)
+                    .setFontWeight("bold")
+                    .setFontColor("#000000")
+                    .setHorizontalAlignment("center")
+                    .setVerticalAlignment("middle");
+
+                stampRow2
+                    .setFontSize(9)
+                    .setFontWeight("normal")
+                    .setFontColor("#000000")
+                    .setHorizontalAlignment("center")
+                    .setVerticalAlignment("middle")
+                    .setWrap(false);
+
+            } else if (labelCounter < allLabels.length) {
+                // ── DELIVERY LABEL ────────────────────────────────────────────
+                const currentLabel = allLabels[labelCounter];
+                const formatting   = labelFontSizeMap[currentLabel.DeliveryIndex];
+                const nameFontSize = formatting ? formatting.name : 12;
+
+                let row2Content = "";
+                if (config.includeDriverNames)               row2Content = currentLabel.Driver;
+                else if (config.includeRouteNames)           row2Content = currentLabel.Route;
+                else if (config.includeAbbreviatedRouteNames) row2Content = currentLabel.AbbrevRoute;
+
+                const detailFontSize = row2Content.length > 20 ? 11 : 13;
+
+                const row2Range = outputSheet.getRange(r + 1, colNameStart, 1, 2);
+                if (!row2Range.isPartOfMerge()) row2Range.mergeAcross();
+
                 outputSheet.getRange(r, colNameStart, 1, 1)
                     .setFontSize(nameFontSize)
                     .setWrap(false)
                     .setFontColor("#000000")
                     .setHorizontalAlignment("center");
-                
-                // Row 1, Bag Number Cell (Fixed Font Size)
+
                 outputSheet.getRange(r, colBagStart, 1, 1)
                     .setFontSize(10)
                     .setFontWeight("normal")
                     .setHorizontalAlignment("left");
 
-                // Row 2, Driver Name Cell 
-                // We format a 2-column range (merged or not) for consistency
-                const driverRange = outputSheet.getRange(r + 1, colNameStart, 1, 2); 
-                driverRange
-                    .setFontSize(driverFontSize) 
-                    .setFontColor(config.includeDriverNames ? "#3C78D8" : "#000000")
-                    .setHorizontalAlignment("center"); 
-                
+                row2Range
+                    .setFontSize(detailFontSize)
+                    .setFontColor(row2Content !== "" ? "#3C78D8" : "#000000")
+                    .setHorizontalAlignment("center");
+
                 labelCounter++;
             } else {
-                // Slot is empty filler (no specific formatting needed, general block formatting applies)
-                labelCounter++; // Still need to advance the counter to properly stop the loop
+                // ── EMPTY FILLER ──────────────────────────────────────────────
+                // Nothing to format; labelCounter intentionally not advanced
+                // (filler slots don't consume allLabels entries)
             }
         }
+
+        rowPairIndex++;
     }
     
     // 4. Safely delete excess rows and columns
@@ -3057,18 +3043,48 @@ function makePackingListThenPDF() {
     SpreadsheetApp.getUi().alert(`✅ Special Items PDF created: "${filename}" - check your Google Drive!`);
 }
 
-function makeLabelsPDF() {
+/**
+ * Asks which label mode to use, generates the sheet, then exports to PDF.
+ * Called directly from the menu OR from makeAllPDFs (which passes a mode).
+ * @param {string} [forcedMode] - optional: "drivers"|"routes"|"abbreviated"|"none"
+ *                                Pass this from makeAllPDFs to skip the prompt.
+ */
+function makeLabelsPDF(forcedMode) {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
-    
-    // 1. CAPTURE THE TIMESTAMP from the first function
-    //const timestamp = generateWithoutDrivers();
-    //const timestamp = generateWithDrivers();
-    const timestamp = generateWithRoutes();
-    //const timestamp = generateWithAbbreviatedRoutes();
-    
-     
-    
-    // In makeLabelsPDF, change your check to this:
+    const ui = SpreadsheetApp.getUi();
+
+    // 1. Determine mode — prompt the user unless a mode was passed in
+    let mode = forcedMode;
+    if (!mode) {
+      const response = ui.prompt(
+        '📦 Label Mode',
+        'Which label style?\n\n' +
+        '  1 — Driver names\n' +
+        '  2 — Full route names\n' +
+        '  3 — Abbreviated route codes\n' +
+        '  4 — No extra info (name + bag count only)\n\n' +
+        'Type a number (1–4) and click OK:',
+        ui.ButtonSet.OK_CANCEL
+      );
+      if (response.getSelectedButton() !== ui.Button.OK) return;
+      const choice = response.getResponseText().trim();
+      const modeMap = { '1':'drivers', '2':'routes', '3':'abbreviated', '4':'none' };
+      mode = modeMap[choice];
+      if (!mode) {
+        ui.alert('Invalid choice. Please enter 1, 2, 3, or 4.');
+        return;
+      }
+    }
+
+    // 2. Generate the label sheet in the chosen mode
+    const modeConfig = {
+      drivers:      { includeDriverNames: true },
+      routes:       { includeRouteNames: true },
+      abbreviated:  { includeAbbreviatedRouteNames: true },
+      none:         {}
+    };
+    const timestamp = generateDeliveryLabels(modeConfig[mode]);
+
     if (!timestamp || timestamp === "ERROR_NO_SHEET") {
       console.log("PDF generation cancelled: No timestamp returned.");
       return; 
@@ -3131,10 +3147,44 @@ function makeLabelsPDF() {
     SpreadsheetApp.getUi().alert(`✅ Printable Lables PDF created: "${filename}" - check your Google Drive! Download it from Google Drive, Open it in Adobe Reader, when you go to print it, select "Fit" instead of "Actual Size"`);
 }
 
+/**
+ * Generates the DeliveryLabels sheet only (no PDF). Prompts for mode.
+ * Wired to Distribution Day Tasks menu item 5.
+ */
+function makeTheLabels() {
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.prompt(
+    '📦 Label Mode',
+    'Which label style?\n\n' +
+    '  1 — Driver names\n' +
+    '  2 — Full route names\n' +
+    '  3 — Abbreviated route codes\n' +
+    '  4 — No extra info (name + bag count only)\n\n' +
+    'Type a number (1–4) and click OK:',
+    ui.ButtonSet.OK_CANCEL
+  );
+  if (response.getSelectedButton() !== ui.Button.OK) return;
+  const choice = response.getResponseText().trim();
+  const modeMap = {
+    '1': { includeDriverNames: true },
+    '2': { includeRouteNames: true },
+    '3': { includeAbbreviatedRouteNames: true },
+    '4': {}
+  };
+  const config = modeMap[choice];
+  if (!config) {
+    ui.alert('Invalid choice. Please enter 1, 2, 3, or 4.');
+    return;
+  }
+  generateDeliveryLabels(config);
+}
+
 function makeAllPDFs() {
   makeDriverRouteTabsThenPDF();
   makePackingListThenPDF();
-  makeLabelsPDF();
+  // Use abbreviated route codes as the default for the bulk "make everything" run.
+  // Change the argument to 'drivers', 'routes', or 'none' if preferred.
+  makeLabelsPDF('abbreviated');
   SpreadsheetApp.getUi().alert('🎉 All 3 PDFs generated successfully!');
 }
 
@@ -3195,27 +3245,34 @@ function clearMapFilter() {
 
 function onOpen() {
   const ui = SpreadsheetApp.getUi();
+
   ui.createMenu("📦 Distribution Day Tasks")
     .addItem("1. Filter Data for Map (Col I)", "filterForMapCreation")
     .addItem("2. Clear Map Data Filter", "clearMapFilter")
-    .addSeparator() 
+    .addSeparator()
     .addItem("3. Make/Update Driver Route Tabs", "makeDriverRouteTabs")
     .addItem("4. Make/Update Packing Lists Tab", "makePackingLists")
-    .addItem("5. Make/Update Printable Packing Labels Tab", "makeTheLabels")
+    .addItem("5. Make/Update Delivery Labels Tab", "makeTheLabels")
     .addSeparator()
-    .addItem("6. Make Driver Route Tabs then the PDF", "makeDriverRouteTabsThenPDF")
+    .addItem("6. Make Driver Route Tabs then PDF", "makeDriverRouteTabsThenPDF")
     .addItem("7. Make Packing Lists Tab then PDF", "makePackingListThenPDF")
-    .addItem("8. Make Printable Packing Labels Tab then PDF", "makeLabelsPDF") 
+    .addItem("8. Make Delivery Labels Tab then PDF", "makeLabelsPDF")
     .addSeparator()
-    .addItem("9. Make All PDFs (Click OK on all 4 pop up messages)", "makeAllPDFs")
+    .addItem("9. Make All PDFs", "makeAllPDFs")
     .addToUi();
-  ui.createMenu('📦 Label Generator')
-      .addItem('Generate Labels (w/ Drivers, Continuous)', 'generateWithDrivers')
-      .addItem('Generate Labels (w/ Routes, Continuous)', 'generateWithRoutes')
-      .addItem('Generate Labels (w/ AbbreviatedRoutes, Continuous)', 'generateWithAbbreviatedRoutes')
-      .addItem('Generate Labels (w/o Drivers/Routes, Continuous)', 'generateWithoutDrivers')
+
+  // Label Generator: each item generates the sheet only (no PDF prompt).
+  // Use item 8 above or the PDF option below to also export.
+  ui.createMenu("📦 Label Generator")
+    .addItem("Labels — Driver Names",          "generateWithDrivers")
+    .addItem("Labels — Full Route Names",       "generateWithRoutes")
+    .addItem("Labels — Abbreviated Route Codes","generateWithAbbreviatedRoutes")
+    .addItem("Labels — No Route Info",          "generateWithoutDrivers")
+    .addSeparator()
+    .addItem("Labels — Choose Mode + Export PDF","makeLabelsPDF")
     .addToUi();
+
   ui.createMenu("📦 Sheet Tools")
-    .addItem('Delete Route Sheets', 'deleteSheetsByPrefix')
+    .addItem("Delete Route Sheets", "deleteSheetsByPrefix")
     .addToUi();
 }

--- a/Code.js
+++ b/Code.js
@@ -2096,65 +2096,313 @@ function formatKeywords(text) {
   return hasFormatting ? builder.build() : text;
 }
 
-function makeTheLabels() {
+function abbreviateRoute(route) {
+  if (!route || route === "UNKNOWN ROUTE") return "No Route";
+  const styleMap = {
+    "Chula Vista": "CV", "Encanto/Lemon Grove": "Enc/LG",
+    "Mountain View/National City": "MtV/NC", "Grantville/College East": "Gv/CE",
+    "Lake Murray/La Mesa": "LkM/LM", "Walking Delivery": "Walking",
+    "Logan Heights": "Logan Hts", "North Coast": "N. Coast"
+  };
+  let shortened = route;
+  for (let [full, short] of Object.entries(styleMap)) {
+    if (shortened.includes(full)) shortened = shortened.replace(full, short);
+  }
+  return shortened.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * DIAGNOSTIC TOOL: 
+ * Run this to see exactly what the script is "seeing" for Row 2 
+ * before any grid logic or merging happens.
+ */
+function debugRow2Contents(config = {}) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const dataSheet = ss.getSheetByName("Deliveries-UPDATE HERE");
+  const debugSheetName = "DEBUG_Row2_Contents";
+  
+  // 1. Setup or Clear the Debug Tab
+  let debugSheet = ss.getSheetByName(debugSheetName);
+  if (!debugSheet) {
+    debugSheet = ss.insertSheet(debugSheetName);
+  }
+  debugSheet.clear().appendRow(["Recipient Name", "Selected Row 2 Content", "Mode Used"]);
+
+  if (!dataSheet) return;
+
+  const data = dataSheet.getDataRange().getValues();
+  const headers = data[0];
+  const dataRows = data.slice(1);
+
+  // 2. Map Indices and Helpers
+  const nameIdx = headers.indexOf("Name");
+  const routeIdx = headers.indexOf("routeDescription");
+  const confForIdx = headers.findIndex(h => h.toString().startsWith("Conf for"));
+  
+  const routeDriverMap = {};
+  const helperSheet = ss.getSheetByName("DeliveriesHelpTable");
+  if (helperSheet) {
+    helperSheet.getDataRange().getValues().slice(1).forEach(row => {
+      if (row[0]) routeDriverMap[String(row[0]).trim()] = String(row[1] || 'TBD').trim();
+    });
+  }
+
+  const debugLog = [];
+  const modeLabel = config.includeDriverNames ? "Driver" : 
+                    config.includeRouteNames ? "Route" : 
+                    config.includeAbbreviatedRouteNames ? "Abbrev" : "None";
+
+  // 3. Process the data exactly like the label maker does
+  dataRows.filter(row => {
+    const confValue = String(row[confForIdx] || '').toUpperCase();
+    return confValue === 'YES' || confValue.includes('NO ANS');
+  }).forEach(row => {
+    const name = String(row[nameIdx] || 'UNKNOWN');
+    const fullRoute = String(row[routeIdx] || 'UNKNOWN ROUTE').trim();
+    const driverName = routeDriverMap[fullRoute] || "TBD";
+    const abbrevRoute = abbreviateRoute(fullRoute);
+
+    // THE DECISION POINT (Same logic as the label generator)
+    let selection = "";
+    if (config.includeDriverNames) selection = driverName;
+    else if (config.includeRouteNames) selection = fullRoute;
+    else if (config.includeAbbreviatedRouteNames) selection = abbrevRoute;
+
+    debugLog.push([name, selection, modeLabel]);
+  });
+
+  // 4. Output to Column A (and B for reference)
+  if (debugLog.length > 0) {
+    debugSheet.getRange(2, 1, debugLog.length, 3).setValues(debugLog);
+    debugSheet.autoResizeColumns(1, 3);
+    SpreadsheetApp.getUi().alert(`Debug Complete. Check the "${debugSheetName}" tab.`);
+  } else {
+    SpreadsheetApp.getUi().alert("No confirmed deliveries found during debug.");
+  }
+}
+
+/**
+ * ULTRA-FAST DIAGNOSTIC
+ * This bypasses all formatting to avoid the 6-minute timeout.
+ * It outputs only the Row 2 content for every delivery to a new tab.
+ */
+function fastDebugRow2() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const dataSheet = ss.getSheetByName("Deliveries-UPDATE HERE");
+  const helperSheet = ss.getSheetByName("DeliveriesHelpTable");
+  const debugSheetName = "DEBUG_RESULTS";
+  
+  // 1. Setup Sheet
+  let debugSheet = ss.getSheetByName(debugSheetName) || ss.insertSheet(debugSheetName);
+  debugSheet.clear();
+
+  // 2. Load ALL Data into Memory at once (Crucial for speed)
+  const data = dataSheet.getDataRange().getValues();
+  const headers = data[0];
+  const nameIdx = headers.indexOf("Name");
+  const routeIdx = headers.indexOf("routeDescription");
+  const confForIdx = headers.findIndex(h => h.toString().startsWith("Conf for"));
+
+  const routeDriverMap = {};
+  if (helperSheet) {
+    const helperData = helperSheet.getDataRange().getValues();
+    for (let i = 1; i < helperData.length; i++) {
+      if (helperData[i][0]) routeDriverMap[String(helperData[i][0]).trim()] = helperData[i][1];
+    }
+  }
+
+  // 3. Process Logic
+  const outputValues = [["RECIPIENT", "ROW 2 CONTENT (ABBREVIATED)"]];
+  
+  data.slice(1).forEach(row => {
+    const confValue = String(row[confForIdx] || '').toUpperCase();
+    if (confValue === 'YES' || confValue.includes('NO ANS')) {
+      const name = row[nameIdx];
+      const fullRoute = String(row[routeIdx] || '').trim();
+      
+      // We are testing the abbreviation specifically here
+      const result = abbreviateRoute(fullRoute); 
+      
+      outputValues.push([name, result]);
+    }
+  });
+
+  // 4. One single write operation (Fast!)
+  if (outputValues.length > 0) {
+    debugSheet.getRange(1, 1, outputValues.length, 2).setValues(outputValues);
+    SpreadsheetApp.getUi().alert("Done! Check the DEBUG_RESULTS tab.");
+  }
+}
+
+// --- Menu Wrappers for Debugging ---
+function debugDrivers() { debugRow2Contents({ includeDriverNames: true }); }
+function debugRoutes() { debugRow2Contents({ includeRouteNames: true }); }
+function debugAbbrev() { debugRow2Contents({ includeAbbreviatedRouteNames: true }); }
+function debugNull() { debugRow2Contents }
+
+function generateDeliveryLabels(config = {}) {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const dataSheet = ss.getSheetByName("Deliveries-UPDATE HERE");
     const outputSheetName = "DeliveryLabels";
     let outputSheet = ss.getSheetByName(outputSheetName);
 
-    const timestamp = Utilities.formatDate(new Date(), ss.getSpreadsheetTimeZone(), "yyyy/MM/dd HH:mm:ss");
-
-    // --- NEW: Calculate the desired insertion index and log details ---
-    let targetIndex;
-    
-    if (dataSheet) {
-        // Log the details of the source sheet
-        Logger.log(`Source Sheet ("${dataSheet.getName()}") Index: ${dataSheet.getIndex()}`);
-
-        // FIX: Insert the new sheet immediately AFTER the source data sheet.
-        // Sheets are 1-indexed. To place AFTER index N, we use N + 1.
-        targetIndex = dataSheet.getIndex() + 1; 
-        
-        // Log the calculated index
-        Logger.log(`Calculated Target Index (Insert AFTER data sheet): ${targetIndex}`);
-        
-        // If you wanted it at the very end, regardless of location, you would use:
-        // targetIndex = ss.getNumSheets(); 
-    } else {
-        // Fallback: Insert at the very end of the sheet list if the data sheet is not found.
-        targetIndex = ss.getNumSheets();
-        Logger.log(`Source sheet "Deliveries-UPDATE HERE" not found. Inserting at the end (Index: ${targetIndex}).`);
-    }
-    // ----------------------------------------------------
-
-    // Only insert the sheet if it doesn't already exist.
+    // 1. Setup Sheet (Preserving your specific index/clear logic)
+    if (!dataSheet) return;
     if (!outputSheet) {
-        // We now use the calculated targetIndex instead of the hardcoded 0.
-        outputSheet = ss.insertSheet(outputSheetName, targetIndex); 
-        Logger.log(`Output sheet created at index: ${outputSheet.getIndex()}`);
-    } else {
-        // If the sheet already exists, its position is not changed by this function
-        Logger.log(`Output sheet ("${outputSheetName}") found at index: ${outputSheet.getIndex()}. Position not changed.`);
+        outputSheet = ss.insertSheet(outputSheetName, dataSheet.getIndex() + 1);
     }
-
-    // Completely clear previous content, formatting, filters
     outputSheet.clear();
-    outputSheet.setFrozenRows(0);
-    outputSheet.setFrozenColumns(0);
 
     const data = dataSheet.getDataRange().getValues();
     const headers = data[0];
     const dataRows = data.slice(1);
 
-    // --- 1. Identify Key Indices ---
+    // 2. Map All Indices and Helpers Upfront
     const nameIdx = headers.indexOf("Name");
     const routeIdx = headers.indexOf("routeDescription");
+    const confForIdx = headers.findIndex(h => h.toString().startsWith("Conf for"));
     
-    // Locate the "Conf for" column (case-insensitive find)
+    // Mapping for Row 2 Data (Driver Info)
+    const routeDriverMap = {};
+    const helperSheet = ss.getSheetByName("DeliveriesHelpTable");
+    if (helperSheet) {
+        helperSheet.getDataRange().getValues().slice(1).forEach(row => {
+            if (row[0]) routeDriverMap[String(row[0]).trim()] = String(row[1] || 'TBD').trim();
+        });
+    }
+
+    const finalOutput = [];
+    const labelFormatting = [];
+
+    // 3. Filter and Build Content
+    dataRows.filter(row => {
+        const confValue = String(row[confForIdx] || '').toUpperCase();
+        return confValue === 'YES' || confValue.includes('NO ANS');
+    }).forEach(row => {
+        // --- DATA GATHERING (The "Decision Point" Preparation) ---
+        const name = String(row[nameIdx] || 'UNKNOWN');
+        const fullRoute = String(row[routeIdx] || 'UNKNOWN ROUTE').trim();
+        const driverName = routeDriverMap[fullRoute] || "TBD";
+        const abbrevRoute = abbreviateRoute(fullRoute); // Your helper function
+
+        // Determine Bag Count (Keeping your logic)
+        let bagCount = calculateBagCount(row, headers); // Helper used to keep this clean
+        bagCount = Math.min(bagCount, 3);
+
+        if (bagCount > 0) {
+            const row1Data = [];
+            const row2Data = [];
+
+            for (let j = 0; j < 3; j++) { // Avery 6240: 3 Labels per Row
+                if (j < bagCount) {
+                    // ROW 1: Constant Name | Bag Info
+                    row1Data.push(name, `BAG ${j + 1} of ${bagCount}`);
+
+                    // ROW 2: The Unified Decision Point
+                    let selection = "";
+                    if (config.includeDriverNames) selection = driverName;
+                    else if (config.includeRouteNames) selection = fullRoute;
+                    else if (config.includeAbbreviatedRouteNames) selection = abbrevRoute;
+
+                    row2Data.push(selection, ""); // Push to Col 1, Col 2 is empty for merge
+                } else {
+                    row1Data.push("", "");
+                    row2Data.push("", "");
+                }
+            }
+            finalOutput.push(row1Data, row2Data);
+            
+            // Store specific fonts based on the data we just pulled
+            labelFormatting.push({
+                nameSize: name.length > 20 ? 10 : 12,
+                detailSize: driverName.length > 20 ? 11 : 13 
+            });
+        }
+    });
+
+    // 4. Write and Format (Using your exact dimensions)
+    if (finalOutput.length > 0) {
+        outputSheet.getRange(1, 1, finalOutput.length, 6).setValues(finalOutput);
+        
+        // This function holds your "painstakingly worked out" dimensions
+        applyStrictGridFormatting(outputSheet, finalOutput.length, labelFormatting);
+    }
+}
+
+/**
+ * Avery 6240 dimensions
+ */
+function applyStrictGridFormatting(sheet, totalRows, formatting) {
+    const width = 258;
+    // Set widths: 70% for info, 30% for bag number
+    [1, 3, 5].forEach(c => sheet.setColumnWidth(c, width * 0.7));
+    [2, 4, 6].forEach(c => sheet.setColumnWidth(c, width * 0.3));
+
+    for (let r = 1; r <= totalRows; r += 2) {
+        sheet.setRowHeight(r, 51.5);
+        sheet.setRowHeight(r + 1, 51.5);
+        
+        const fmt = formatting[(r - 1) / 2];
+
+        for (let c = 1; c <= 5; c += 2) {
+            // Row 1 Style
+            sheet.getRange(r, c).setFontSize(fmt.nameSize).setFontWeight("bold");
+            sheet.getRange(r, c+1).setFontSize(10).setHorizontalAlignment("right");
+
+            // Row 2 Style
+            const row2Range = sheet.getRange(r + 1, c, 1, 2);
+            if (!row2Range.isPartOfMerge()) row2Range.mergeAcross();
+            row2Range.setFontSize(fmt.detailSize)
+                     .setFontColor("#3C78D8")
+                     .setHorizontalAlignment("center");
+        }
+    }
+}
+
+// Menu Wrappers
+function generateWithoutDrivers() { generateDeliveryLabels({}); }
+function generateWithDrivers() { generateDeliveryLabels({ includeDriverNames: true }); }
+function generateWithRoutes() { generateDeliveryLabels({ includeRouteNames: true }); }
+function generateWithAbbreviatedRoutes() { generateDeliveryLabels({ includeAbbreviatedRouteNames: true }); }
+
+/**
+ * Core logic to build the label content based on user requirements.
+ * This respects the 2-row-per-label grid.
+ */
+function generateDeliveryLabels(config = {}) {
+    const defaults = {
+        includeDriverNames: false,
+        includeRouteNames: false,
+        includeAbbreviatedRouteNames: false
+    };
+    const finalConfig = { ...defaults, ...config };
+    
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const dataSheet = ss.getSheetByName("Deliveries-UPDATE HERE");
+    const outputSheetName = "DeliveryLabels";
+    let outputSheet = ss.getSheetByName(outputSheetName);
+
+    if (!dataSheet) {
+        SpreadsheetApp.getUi().alert("Source sheet 'Deliveries-UPDATE HERE' not found.");
+        return;
+    }
+
+    // 1. Setup Sheet (Keep your index logic)
+    if (!outputSheet) {
+        outputSheet = ss.insertSheet(outputSheetName, dataSheet.getIndex() + 1);
+    }
+    outputSheet.clear();
+
+    // 2. Get Data & Indices
+    const data = dataSheet.getDataRange().getValues();
+    const headers = data[0];
+    const dataRows = data.slice(1);
+    const nameIdx = headers.indexOf("Name");
+    const routeIdx = headers.indexOf("routeDescription");
     const confForHeader = headers.find(h => typeof h === 'string' && h.trim().startsWith("Conf for"));
     const confForIdx = confForHeader ? headers.indexOf(confForHeader) : -1;
 
-    // Indices for Bag Count Calculation
+    // Bag Count Indices
     const diapers1Idx = headers.indexOf("diapers1(size)");
     const diapers2Idx = headers.indexOf("diapers2(size)");
     const diapers3Idx = headers.indexOf("diapers3(size)");
@@ -2162,237 +2410,122 @@ function makeTheLabels() {
     const dogFoodIdx = headers.indexOf("dogFood(qty)");
     const catFoodIdx = headers.indexOf("catFood(qty)");
 
-    // Safety check for required columns
-    if (nameIdx === -1 || routeIdx === -1 || confForIdx === -1) {
-        Logger.log("Missing essential columns (Name, routeDescription, or Conf for *). Cannot generate labels.");
-        SpreadsheetApp.getUi().alert("Missing essential columns (Name, routeDescription, or Conf for *). Cannot generate labels.");
-        return;
-    }
-
-    // --- 2. Build Route-Driver Mapping ---
+    // 3. Build Route-Driver Map
     const helperSheet = ss.getSheetByName("DeliveriesHelpTable");
     const routeDriverMap = {};
     if (helperSheet) {
         const helperData = helperSheet.getDataRange().getValues().slice(1);
         helperData.forEach(row => { 
-            const routeKey = String(row[0] || '').trim();
-            const driverValue = String(row[1] || '').trim();
-            if (routeKey) routeDriverMap[routeKey] = driverValue; 
+            if (row[0]) routeDriverMap[String(row[0]).trim()] = String(row[1] || 'TBD').trim(); 
         });
     }
 
-    // --- 3. Filter Data and Process Each Delivery Row ---
-    const deliveriesData = [];
-    const labelFontSizeMap = {}; // Maps the delivery index to font sizes
-    let deliveryIndexCounter = 0; // Counter for mapping purposes
+    // 4. Process Rows
+    const finalOutput = [];
+    const labelFormatting = []; // Store font sizes for later
 
-    const filteredDataRows = dataRows
-        // Filter by Conf for * = 'YES' or includes 'NO ANS'
-        .filter(row => {
-            const confValue = String(row[confForIdx] || '').toUpperCase().trim();
-            return confValue === 'YES' || confValue.includes('NO ANS');
-        });
+    const filteredRows = dataRows.filter(row => {
+        const confValue = String(row[confForIdx] || '').toUpperCase().trim();
+        return confValue === 'YES' || confValue.includes('NO ANS');
+    });
 
-    filteredDataRows.forEach(row => {
+    filteredRows.forEach(row => {
         const name = String(row[nameIdx] || 'UNKNOWN NAME');
         const route = String(row[routeIdx] || 'UNKNOWN ROUTE').trim();
         const driver = routeDriverMap[route] || "TBD";
-        
-        // Dynamic Font Size Emulation for Name
-        const baseNameFontSize = 12;
-        const reducedNameFontSize = 10;
-        const maxNameLength = 20; 
-        const nameFontSize = name.length > maxNameLength ? reducedNameFontSize : baseNameFontSize;
 
-        // Dynamic Font Size Emulation for Driver (USING USER'S CUSTOM VALUES)
-        const baseDriverFontSize = 13;
-        const reducedDriverFontSize = 11;
-        const maxDriverLength = 20;
-        const driverFontSize = driver.length > maxDriverLength ? reducedDriverFontSize : baseDriverFontSize;
+        // Bag Logic (Max 3)
+        let totalBags = 0;
+        if (diapers1Idx !== -1 && String(row[diapers1Idx]).trim() !== "") totalBags++;
+        if (diapers2Idx !== -1 && String(row[diapers2Idx]).trim() !== "") totalBags++;
+        if (diapers3Idx !== -1 && String(row[diapers3Idx]).trim() !== "") totalBags++;
+        totalBags += Math.ceil(parseFloat(row[wipesIdx] || 0));
+        totalBags += Math.ceil(parseFloat(row[dogFoodIdx] || 0)) + Math.ceil(parseFloat(row[catFoodIdx] || 0));
+        totalBags = Math.min(totalBags, 3);
 
+        if (totalBags > 0) {
+            const row1Data = [];
+            const row2Data = [];
 
-        // --- Bag Count Logic (Only counts bulky items) ---
-        let bagCount = 0;
+            for (let j = 0; j < 3; j++) { // 3 labels per row
+                if (j < totalBags) {
+                    // REQUIREMENT 1: Row 1 = Name | Bag # of #
+                    row1Data.push(name, `BAG ${j + 1} of ${totalBags}`);
 
-        // A. Diapers: 1 bag per non-empty column (max 3)
-        if (diapers1Idx !== -1 && String(row[diapers1Idx]).trim() !== "") bagCount++;
-        if (diapers2Idx !== -1 && String(row[diapers2Idx]).trim() !== "") bagCount++;
-        if (diapers3Idx !== -1 && String(row[diapers3Idx]).trim() !== "") bagCount++;
+                    // REQUIREMENT 2: Row 2 Logic based on user options
+                    let row2Content = "";
+                    if (finalConfig.includeDriverNames) {
+                        row2Content = driver;
+                    } else if (finalConfig.includeRouteNames) {
+                        row2Content = route;
+                    } else if (finalConfig.includeAbbreviatedRouteNames) {
+                        row2Content = abbreviateRoute(route);
+                    }
+                    // else: "without drivers or routes" remains ""
 
-        // B. Wipes: 1 bag per whole quantity
-        const wipesQty = parseFloat(row[wipesIdx] || 0) || 0;
-        bagCount += Math.ceil(wipesQty);
-        
-        // C. Pet Food: 1 bag per whole quantity
-        const dogFoodQty = parseFloat(row[dogFoodIdx] || 0) || 0;
-        const catFoodQty = parseFloat(row[catFoodIdx] || 0) || 0;
-        bagCount += Math.ceil(dogFoodQty) + Math.ceil(catFoodQty);
-        
-        // --- IMPLEMENT HARD LIMIT OF 3 LABELS ---
-        bagCount = Math.min(bagCount, 3);
-        
-        if (bagCount > 0) {
-             const delivery = {
-                Name: name,
-                Driver: driver,
-                TotalLabels: bagCount
-            };
-            
-            deliveriesData.push(delivery);
-            
-            // Store font size metadata keyed by the delivery index
-            labelFontSizeMap[deliveryIndexCounter] = { 
-                name: nameFontSize,
-                driver: driverFontSize
-            };
-            deliveryIndexCounter++;
-        }
-    });
-
-    // --- 4. Format Output into Grouped Delivery Layout (2 Rows per Delivery) ---
-    const finalOutput = [];
-    const labelsPerRow = 3;
-    const labelHeightRows = 2; // *** RESTORED: 2 rows per physical label ***
-    const labelWidthCols = 2;  
-    const totalCols = labelsPerRow * labelWidthCols; // 6 columns 
-    
-    // Store the delivery index corresponding to each new row pair for formatting later
-    const outputRowMapping = []; 
-
-    deliveriesData.forEach((delivery, index) => {
-        const row1Data = []; // Name and Bag Numbers
-        const row2Data = []; // Driver Names
-        
-        const numLabelsToGenerate = delivery.TotalLabels;
-
-        for (let j = 0; j < labelsPerRow; j++) {
-            if (j < numLabelsToGenerate) {
-                // Generate content for this label slot
-                const nameLine = `${delivery.Name}`;
-                const detailLine = `${delivery.Driver}`; // Driver Name Only
-                const numberLine = `BAG ${j + 1}/${delivery.TotalLabels}`;
-
-                // Row 1: Name and Bag Number
-                row1Data.push(nameLine, numberLine);
-                // Row 2: Driver Name (Pushed twice for merging later)
-                row2Data.push(detailLine, detailLine); 
-            } else {
-                // Leave the remaining slots blank
-                row1Data.push("", ""); 
-                row2Data.push("", ""); 
+                    row2Data.push(row2Content, ""); // Empty col for merge
+                } else {
+                    row1Data.push("", "");
+                    row2Data.push("", "");
+                }
             }
+            finalOutput.push(row1Data, row2Data);
+            
+            // Store sizing info (matching your painstakingly set fonts)
+            labelFormatting.push({
+                nameSize: name.length > 20 ? 10 : 12,
+                detailSize: driver.length > 20 ? 11 : 13
+            });
         }
-        
-        finalOutput.push(row1Data, row2Data); // Push both rows for the delivery
-        // Store the index of the delivery
-        outputRowMapping.push(index);
     });
-    
-    if (finalOutput.length === 0) {
-        SpreadsheetApp.getUi().alert("No confirmed deliveries with items found to generate labels.");
-        return;
+
+    // 5. Write to Sheet
+    if (finalOutput.length > 0) {
+        outputSheet.getRange(1, 1, finalOutput.length, 6).setValues(finalOutput);
+        applyGridFormatting(outputSheet, finalOutput.length, labelFormatting);
     }
-    
-    // --- 5. Write Data to Sheet ---
-    
-    outputSheet.getRange(1, 1, finalOutput.length, totalCols).setValues(finalOutput);
-
-    // --- 6. Formatting and Sizing for Avery 6240 (30-up) ---
-    
-    // Set column widths for printing (Columns A/B, C/D, E/F form the 3 labels)
-    //const width = 250;
-    const width = 258; 
-    outputSheet.setColumnWidth(1, width * 0.7); // Name/Route Line (70%)
-    outputSheet.setColumnWidth(2, width * 0.3); // Label Number (30%)
-    outputSheet.setColumnWidth(3, width * 0.7);
-    outputSheet.setColumnWidth(4, width * 0.3);
-    outputSheet.setColumnWidth(5, width * 0.7);
-    outputSheet.setColumnWidth(6, width * 0.3);
-    
-
-    // Loop through the output data rows (2 rows per delivery)
-    for (let r = 1; r <= finalOutput.length; r += labelHeightRows) { 
-        
-        // Calculate the index of the current delivery block in outputRowMapping
-        const deliveryIndex = outputRowMapping[(r - 1) / labelHeightRows];
-        const deliveryInfo = deliveriesData[deliveryIndex];
-        const numLabels = deliveryInfo.TotalLabels;
-
-        // *** RESTORED: Set both Row Heights to 36px (36px + 36px = 72px total label height) ***
-        //outputSheet.setRowHeight(r, 36); // Row 1 (Name/Number)
-        //outputSheet.setRowHeight(r + 1, 36); // Row 2 (Driver)
-        outputSheet.setRowHeight(r, 51.5); // Row 1 (Name/Number)
-        outputSheet.setRowHeight(r + 1, 51.5); // Row 2 (Driver)
-
-        // General Formatting for the Label Block (2 rows x 6 columns)
-        const labelBlock = outputSheet.getRange(r, 1, labelHeightRows, totalCols);
-
-        // Explicitly remove all borders (Top, Bottom, Left, Right, Vertical, Horizontal)
-        labelBlock.setBorder(false, false, false, false, false, false); 
-
-        // Align all content to the middle vertically
-        labelBlock.setFontWeight("bold").setVerticalAlignment("middle").setHorizontalAlignment("center");
-        
-        // --- Apply Dynamic Font Sizing for Names and Drivers ---
-
-        // Get the font sizing metadata for this delivery
-        const formatting = labelFontSizeMap[deliveryIndex];
-        const nameFontSize = formatting ? formatting.name : 12; 
-        const driverFontSize = formatting ? formatting.driver : 13; 
-
-        // Apply formatting across all generated labels in this row pair
-        for (let j = 0; j < numLabels; j++) {
-            const colNameStart = j * 2 + 1; // 1, 3, 5
-            const colBagStart = j * 2 + 2; // 2, 4, 6
-
-            // Row 2: Driver Name Merging (Must happen first)
-            outputSheet.getRange(r + 1, colNameStart, 1, 2).mergeAcross();
-            
-            // Row 1, Name Cell (Dynamic Font Size)
-            outputSheet.getRange(r, colNameStart, 1, 1)
-                .setFontSize(nameFontSize)
-                .setWrap(false)
-                .setFontColor("#000000") // Black color
-                .setHorizontalAlignment("center");
-            
-            // Row 1, Bag Number Cell (Fixed Font Size)
-            outputSheet.getRange(r, colBagStart, 1, 1)
-                .setFontSize(10)
-                .setFontWeight("normal")
-                .setHorizontalAlignment("left");
-
-            // Row 2, Driver Name Cell (Dynamic Font Size) - Applies to the merged range
-            outputSheet.getRange(r + 1, colNameStart, 1, 2)
-                .setFontSize(driverFontSize) // *** DYNAMIC FONT SIZE APPLIED HERE ***
-                .setFontColor("#3C78D8") // Blue color
-                .setHorizontalAlignment("center"); 
-        }
-    }
-
-    // --- Safely delete excess rows and columns ---
-    
-    const maxRows = outputSheet.getMaxRows();
-    const rowsToDelete = maxRows - finalOutput.length;
-    if (rowsToDelete > 0) {
-        outputSheet.deleteRows(finalOutput.length + 1, rowsToDelete);
-    }
-    
-    const maxCols = outputSheet.getMaxColumns();
-    const colsToDelete = maxCols - totalCols;
-    if (colsToDelete > 0) {
-        outputSheet.deleteColumns(totalCols + 1, colsToDelete);
-    }
-    
-    SpreadsheetApp.flush();
-
-    return timestamp;
 }
 
+/**
+ * Formatting function strictly maintains your calibrated Avery dimensions
+ */
+function applyGridFormatting(sheet, totalRows, formatting) {
+    const width = 258;
+    sheet.setColumnWidths(1, 6, width * 0.3); // Reset
+    [1, 3, 5].forEach(col => sheet.setColumnWidth(col, width * 0.7));
+    [2, 4, 6].forEach(col => sheet.setColumnWidth(col, width * 0.3));
 
-// Updated function signature for clarity
+    for (let r = 1; r <= totalRows; r += 2) {
+        sheet.setRowHeight(r, 51.5);
+        sheet.setRowHeight(r + 1, 51.5);
+        
+        const fmt = formatting[(r - 1) / 2];
+
+        for (let c = 1; c <= 5; c += 2) {
+            // Row 1 Formatting
+            sheet.getRange(r, c).setFontSize(fmt.nameSize).setFontWeight("bold");
+            sheet.getRange(r, c + 1).setFontSize(10).setHorizontalAlignment("right");
+
+            // Row 2 Formatting (Merged as per your grid)
+            const row2Range = sheet.getRange(r + 1, c, 1, 2);
+            if (!row2Range.isPartOfMerge()) row2Range.mergeAcross();
+            row2Range.setFontSize(fmt.detailSize).setFontColor("#3C78D8").setHorizontalAlignment("center");
+        }
+    }
+}
+
+// Menu Wrappers
+function generateWithoutDrivers() { generateDeliveryLabels({}); }
+function generateWithDrivers() { generateDeliveryLabels({ includeDriverNames: true }); }
+function generateWithRoutes() { generateDeliveryLabels({ includeRouteNames: true }); }
+function generateWithAbbreviatedRoutes() { generateDeliveryLabels({ includeAbbreviatedRouteNames: true }); }
+
+
 function generateDeliveryLabels(config = {}) {
     const defaults = {
-        includeDriverNames: false // Default: Include driver names
+        includeDriverNames: false,
+        includeRouteNames: false,            // New default
+        includeAbbreviatedRouteNames: true   // Per Gavi's request: Default to Abbreviations
     };
     const finalConfig = { ...defaults, ...config };
     
@@ -2401,34 +2534,37 @@ function generateDeliveryLabels(config = {}) {
     const outputSheetName = "DeliveryLabels";
 
     if (!dataSheet) {
-        SpreadsheetApp.getUi().alert("Source sheet 'Deliveries-UPDATE HERE' not found. Cannot generate labels.");
+        SpreadsheetApp.getUi().alert("Source sheet 'Deliveries-UPDATE HERE' not found.");
         return;
     }
     
-    // 1. Setup/Initialization
     const outputSheet = setupOutputSheet(ss, dataSheet, outputSheetName);
-    
-    // 2. Data Extraction and Pre-processing
     const { headers, dataRows } = getSourceData(dataSheet);
     const indices = getColumnIndices(headers);
+
     if (!indices.isValid) {
-        SpreadsheetApp.getUi().alert("Missing essential columns (Name, routeDescription, or Conf for *). Cannot generate labels.");
+        SpreadsheetApp.getUi().alert("Missing essential columns. Cannot generate labels.");
         return;
     }
+
     const routeDriverMap = getRouteDriverMap(ss);
 
-    // 3. Generate Individual Labels (New Flat Structure)
+    // Generate the labels - pass the config here if your label generator 
+    // needs to know about routes early on
     const { allLabels, labelFontSizeMap } = generateAllIndividualLabels(dataRows, indices, routeDriverMap);
 
     if (allLabels.length === 0) {
-        SpreadsheetApp.getUi().alert("No confirmed deliveries with items found to generate labels.");
+        SpreadsheetApp.getUi().alert("No confirmed deliveries found.");
         return;
     }
 
-    // 4. Format Output into Continuous Matrix
-    const { finalOutput, outputLabelMapping } = formatContinuousLabelData(allLabels, finalConfig.includeDriverNames);
+    // --- STEP 4: This is where the magic happens ---
+    // Pass the finalConfig so the formatter knows which string to build
+    const { finalOutput, outputLabelMapping } = formatContinuousLabelData(
+        allLabels, 
+        finalConfig
+    );
     
-    // 5. Write Data and Apply Formatting
     writeAndFormatContinuousLabels(outputSheet, finalOutput, outputLabelMapping, allLabels, labelFontSizeMap, finalConfig);
     
     SpreadsheetApp.flush();
@@ -2446,6 +2582,17 @@ function generateWithoutDrivers() {
     // Adding 'return' ensures the timestamp reaches makeLabelsPDF
     return generateDeliveryLabels({ includeDriverNames: false });
 }
+
+function generateWithRoutes() {
+    // Adding 'return' ensures the timestamp reaches makeLabelsPDF
+    return generateDeliveryLabels({ includeRouteNames: true });
+}
+
+function generateWithAbbreviatedRoutes() {
+    // Adding 'return' ensures the timestamp reaches makeLabelsPDF
+    return generateDeliveryLabels({ includeAbbreviatedRouteNames: true });
+}
+
 // --- Constants for Label Dimensions (Avery 6240) ---
 const LABELS_PER_ROW = 3;
 const LABEL_HEIGHT_ROWS = 2; // 2 rows of Google Sheets = 1 physical label
@@ -2914,10 +3061,10 @@ function makeLabelsPDF() {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     
     // 1. CAPTURE THE TIMESTAMP from the first function
-    //const timestamp = makeTheLabels();
-    //const timestamp = generateDeliveryLabels();
-    const timestamp = generateWithoutDrivers();
+    //const timestamp = generateWithoutDrivers();
     //const timestamp = generateWithDrivers();
+    const timestamp = generateWithRoutes();
+    //const timestamp = generateWithAbbreviatedRoutes();
     
      
     
@@ -3064,7 +3211,9 @@ function onOpen() {
     .addToUi();
   ui.createMenu('📦 Label Generator')
       .addItem('Generate Labels (w/ Drivers, Continuous)', 'generateWithDrivers')
-      .addItem('Generate Labels (w/o Drivers, Continuous)', 'generateWithoutDrivers')
+      .addItem('Generate Labels (w/ Routes, Continuous)', 'generateWithRoutes')
+      .addItem('Generate Labels (w/ AbbreviatedRoutes, Continuous)', 'generateWithAbbreviatedRoutes')
+      .addItem('Generate Labels (w/o Drivers/Routes, Continuous)', 'generateWithoutDrivers')
     .addToUi();
   ui.createMenu("📦 Sheet Tools")
     .addItem('Delete Route Sheets', 'deleteSheetsByPrefix')

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 https://github.com/ej9erfan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PR_makeAllPDFs_removal.md
+++ b/PR_makeAllPDFs_removal.md
@@ -1,0 +1,34 @@
+## Remove `makeAllPDFs` — Serial Manual Execution Model
+
+### Background
+
+`makeAllPDFs` was originally introduced to let the operator kick off all three Distribution Day deliverables in one click and walk away while they generated. At the time, the entire process ran in roughly five minutes — within Apps Script's execution limit — and the result was three PDFs sitting in Google Drive ready to print.
+
+Two things have changed since then:
+
+1. **Each individual deliverable now takes approximately five minutes on its own.** The addition of driver route tabs, packing list formatting, and the full label generation pipeline means the three phases together far exceed the six-minute hard execution limit. Attempts to work around this with continuation triggers and `PropertiesService` state were implemented but proved too slow and too fragile to be reliable.
+
+2. **The "walk away" workflow no longer matches how printing actually works.** The packing lists require very specific print settings that must be configured manually inside the Google Sheets print menu — this step cannot be automated and cannot be skipped. In practice, the operator has to be present for each print job anyway. The Driver Route Sheets and Delivery Labels PDFs also need to be downloaded and opened in Adobe Reader before printing with the correct scale settings.
+
+### What This Changes
+
+The serial manual model is now the intended workflow:
+
+- Run **Make/Update Driver Route Tabs** → immediately start the print job → while it prints, run **Make Packing Lists** → configure and print → while it prints, run **Make Delivery Labels** → print.
+- Each function can be triggered from the menu as soon as the previous print job is queued. The operator stays focused and moves through all three deliverables in one sitting without waiting for automation to finish before starting the next step.
+- This approach also reduces the cognitive load of monitoring a background process and interpreting toast notifications or error states from a multi-phase trigger chain.
+
+### Code Removed
+
+- `makeAllPDFs()` — the entry point function
+- `_makeAllPDFs_continue()` — the time-based trigger continuation handler
+- `_clearContinuationTrigger()` — the trigger cleanup helper
+- Menu item **9. Make All PDFs** from the Distribution Day Tasks menu
+- All `PropertiesService` phase state management
+
+### Nothing Else Changes
+
+The three individual "make X then PDF" functions (`makeDriverRouteTabsThenPDF`, `makePackingListThenPDF`, `makeLabelsPDF`) are unchanged. The Label Generator menu is unchanged. Menu items 1–8 are unchanged.
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,224 @@
+# Distribution Day Deliverables — README
+
+This document explains how the Google Sheets automation works, what it produces, how to run it, and how to print everything correctly on Distribution Day.
+
+---
+
+## What Gets Generated
+
+Running the automation produces **three deliverables**:
+
+| # | Deliverable | File Name | Printed On |
+|---|---|---|---|
+| 1 | Driver Route Sheets | `Driver_Route_Sheets_<timestamp>.pdf` | Regular paper |
+| 2 | Packing Lists | `Packing_Lists_<timestamp>.pdf` | Regular paper (printed from Sheets, not Adobe) |
+| 3 | Delivery Labels | `Printable_Labels_<timestamp>.pdf` | Avery 6240 label sheets |
+
+All three PDF files are saved automatically to your **Google Drive**.
+
+---
+
+## Prerequisites — The Source Sheet
+
+Everything runs from the **`Deliveries-UPDATE HERE`** tab. That sheet must have the following column headers (exact spelling matters):
+
+| Column | Description |
+|---|---|
+| `Name` | Recipient name |
+| `Address` | Delivery address |
+| `Phone` | Phone number |
+| `routeDescription` | The route name — must match entries in `DeliveriesHelpTable` |
+| `Driver` | Assigned driver name |
+| `Conf for <date>` | Confirmation status — rows must say `YES` or contain `NO ANS` to be included |
+| `diapers1(size)` | First diaper size (if any) |
+| `diapers2(size)` | Second diaper size (if any) |
+| `diapers3(size)` | Third diaper size (if any) |
+| `wipes(qty)` | Wipes quantity |
+| `dogFood(qty)` | Dog food quantity |
+| `catFood(qty)` | Cat food quantity |
+| `# packs` | Food pack count |
+| `# eggs` | Egg count |
+| `# milk` | Milk count |
+| `Special Item Requests` | Free-text special items |
+| `Special Delivery Instructions` | Free-text delivery notes |
+| `Delivery Map Links` | Hyperlink to the route map |
+
+> **Note:** Only rows where `Conf for` equals `YES` or contains `NO ANS` are included in any deliverable. Rows marked `NO` or left blank are skipped.
+
+---
+
+## Running the Automation
+
+### Recommended Workflow — Serial, Manual, One Sitting
+
+Each deliverable takes around five minutes to generate. The intended approach is to run them one at a time and overlap the print jobs:
+
+1. Click **6. Make Driver Route Tabs then PDF** → while it runs, set up your printer
+2. When the Driver Route Sheets PDF is in Drive, start that print job
+3. While it prints, click **7. Make Packing Lists Tab then PDF**
+4. When the Packing Lists PDF is ready, configure and print it (see Printing section below)
+5. While it prints, click **8. Make Delivery Labels Tab then PDF**
+6. Print the labels last
+
+This keeps you moving through all three deliverables in one focused sitting without waiting for one phase to finish before starting the next.
+
+> **Why not "Make All PDFs" in one click?** That function has been removed. Each deliverable now takes ~5 minutes on its own, which exceeds the Apps Script execution limit. More importantly, the Packing Lists require manual print settings that can't be automated, so the operator has to be present for each print job regardless.
+
+---
+
+### What Happens During Each Phase
+
+**Phase 1 — Driver Route Tabs**
+The script rebuilds the `DeliveriesHelpTable` (route → driver mapping), then creates one new sheet tab per route. Each tab contains a header with the driver name, route name, map link, item totals, and a stop-by-stop delivery table. The old route tabs are deleted first. This takes 30–45 seconds. Do not interrupt it.
+
+**Phase 2 — Packing Lists**
+The script generates the `PackingLists` tab with item summaries, confirmation counts, a diaper reference table, and a full section-by-section breakdown of every stop on every route.
+
+**Phase 3 — Delivery Labels**
+The script generates the `DeliveryLabels` tab formatted for Avery 6240 label sheets (30 labels per sheet, 10 rows × 3 columns). The bottom-right label on every sheet is a **page number + timestamp stamp** instead of a delivery label. Each label shows the recipient name, bag count (e.g. `BAG 2/3`), and optionally a driver name, route name, or abbreviated route code on the second line.
+
+---
+
+### The Slower Way — Generate Sheets and PDFs Individually
+
+Use the **📦 Distribution Day Tasks** menu for step-by-step control:
+
+| Item | What it does |
+|---|---|
+| 1. Filter Data for Map (Col I) | Filters the source sheet to show only rows with a map link, for use with route mapping tools |
+| 2. Clear Map Data Filter | Removes that filter |
+| 3. Make/Update Driver Route Tabs | Rebuilds the per-route driver sheets only (no PDF) |
+| 4. Make/Update Packing Lists Tab | Rebuilds the PackingLists tab only (no PDF) |
+| 5. Make/Update Delivery Labels Tab | Rebuilds the DeliveryLabels tab only — prompts you to choose a label style |
+| 6. Make Driver Route Tabs then PDF | Rebuilds driver tabs and exports the PDF to Drive |
+| 7. Make Packing Lists Tab then PDF | Rebuilds packing list and exports the PDF to Drive |
+| 8. Make Delivery Labels Tab then PDF | Prompts for label style, then generates the sheet and exports the PDF |
+
+---
+
+### Label Style Options
+
+When prompted for a label style (menu items 5 and 8, or the Label Generator menu), enter:
+
+| # | Style | Row 2 of each label shows |
+|---|---|---|
+| 1 | Driver Names | The assigned driver's name |
+| 2 | Full Route Names | The full `routeDescription` value |
+| 3 | Abbreviated Route Codes | A short code (see table below) |
+| 4 | No Route Info | Blank — name and bag count only |
+
+You can also generate labels directly without a PDF prompt from the **📦 Label Generator** menu.
+
+---
+
+### Abbreviated Route Codes
+
+When using style **3 — Abbreviated Route Codes**, the second row of each label shows a short code formatted as:
+
+- **Standard:** `NCOAST 2` — 6 letters + space + number
+- **Directional:** `CHVST W 1` — 5 letters + space + direction + space + number
+- **No number** when only one route exists with that name (e.g. `AZALEA`, `NORMHT`, `GRNTVI`)
+
+| Route | Code |
+|---|---|
+| Downtown | `DTOWN 1` / `DTOWN 2` |
+| North Coast | `NCOAST 1` / `NCOAST 2` |
+| Normal Heights | `NORMHT` |
+| Azalea | `AZALEA` |
+| Teralta | `TERALT 1` / `TERALT 2` |
+| El Cajon | `ELCAJO 1` / `ELCAJO 2` / `ELCAJO 3` |
+| Chula Vista East | `CHVST E 1` |
+| Chula Vista West | `CHVST W 1` / `CHVST W 2` / `CHVST W 3` |
+| Encanto / Lemon Grove | `ENCNTO 1` / `ENCNTO 2` |
+| Mountain View / National City | `MTNVCY 1` / `MTNVCY 2` |
+| Grantville / College East | `GRNTVI` |
+| Lake Murray / La Mesa | `LMRAY 1` / `LMRAY 2` |
+| Logan Heights | `LOGANH 1` / `LOGANH 2` |
+| Walking Delivery | `WLKDLV 1` / `WLKDLV 2` |
+| Volunteers | `VOLNTR` |
+
+> **Adding a new route:** Open `Code.js`, find the `ROUTE_MAP` inside `abbreviateRoute()`, and add one line: `"Exact Route Name": "NEWCOD"`. If the new code ends in the letter N, S, E, or W and has a 5-letter prefix, it will be treated as a directional code — choose a different ending letter to avoid that.
+
+---
+
+## Printing
+
+### Driver Route Sheets
+
+1. Download `Driver_Route_Sheets_<timestamp>.pdf` from Google Drive
+2. Open in **Adobe Acrobat/Reader** (not the browser)
+3. Click the print icon
+4. Set scale to **Fit** (not Actual Size)
+5. Make sure **Print on both sides** is **off**
+6. Click Print
+
+**Print the Walking Delivery pages a second time** — print only the Walking Delivery route sheets again so there are two copies. Delivery teams sometimes split up those stops.
+
+---
+
+### Delivery Labels
+
+1. Download `Printable_Labels_<timestamp>.pdf` from Google Drive
+2. Open in **Adobe Acrobat/Reader**
+3. Load **Avery 6240** label sheets into your printer
+   - ⚠️ Use Avery brand. Office Depot brand labels do not stick to grocery bags reliably.
+4. Set scale to **Fit** (not Actual Size)
+5. Make sure **Print on both sides** is **off**
+6. Click Print
+
+---
+
+### Packing Lists
+
+The Packing Lists PDF **cannot** be printed from Adobe because Adobe won't let you set custom page breaks. Print directly from Google Sheets instead:
+
+1. Go to the **PackingLists** tab in the Google Sheet
+2. Click **File → Print**
+3. Set **Scale** to **Fit to Width**
+4. Set **Margins** to **Custom Numbers** and change all four values to **0.15**
+5. Click into the **page break preview** — you will see blue dotted lines
+6. Drag the blue lines to set page breaks so that 2–3 routes fit per page, with the timestamp/generation message visible on the first page
+7. Once all page breaks look correct, click **Confirm Breaks** (upper right)
+8. In the left panel, click **Headers and Footers** and check:
+   - ✅ Page Numbers
+   - ✅ Sheet Name
+9. Click **Next**, then **Print**
+
+**Print page 1 two extra times:**
+After printing the full list, print just page 1 again twice (enter `1, 1` in the custom page range). The first page contains the item summary and is referenced frequently during packing.
+
+---
+
+## End of Process Checklist
+
+When everything is done, you should have:
+
+- 📄 **Driver Route Sheets** — one copy per driver, plus an extra copy of any Walking Delivery pages
+- 📋 **Packing Lists** — full set, plus two extra copies of page 1
+- 🏷️ **Label sheets** — one full printed set on Avery 6240 stock
+
+Bring all of them to Distro!
+
+---
+
+## Running Order Reference
+
+```
+Menu item 6  →  print Driver Route Sheets
+Menu item 7  →  configure + print Packing Lists
+Menu item 8  →  print Delivery Labels
+```
+
+Start the next function as soon as the previous print job is queued. All three can be in progress simultaneously.
+---
+
+## Community & Solidarity
+
+This project is licensed under **MIT** — deliberately. MIT was chosen so that other mutual aids and community orgs can pick this up, adapt it for their own context, and decide for themselves how openly they share what they build. No one is required to expose their volunteers, their data structures, or their internal processes. You set your own boundaries.
+
+That said — if your org adapts this and you want to share what you've built or learned, we'd genuinely love to hear from it. Comparing notes across mutual aid networks makes all of us more effective.
+
+🐙 **[github.com/ej9erfan](https://github.com/ej9erfan)**
+💬 **[Open a Discussion](https://github.com/ej9erfan/WAWG-Distribution-Scripts/discussions)** on the repo — other mutual aids can see it too
+
+Solidarity.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>PR: Delivery Label Generation — Route Abbreviations &amp; Multi-Mode Support</h1>
<h2>Summary</h2>
<p>Adds four label generation modes to the Delivery Labels tab, with <strong>Abbreviated Route Codes</strong> as the default. Cleans up duplicate dead code left by prior AI-assisted development, fixes several bugs where non-driver modes were silently falling back to the wrong output, and wires all modes correctly into both the Label Generator menu and the Distribution Day Tasks workflow.</p>
<hr>
<h2>Background</h2>
<p>Per G: route names are too long to read quickly on a label during a fast-paced distribution day. A short code like <code>CVW 1</code> instead of <code>Chula Vista West 1</code> keeps bags grouped by location, makes route reassignments easier to communicate on the fly, and is readable from across a room.</p>
<hr>
<h2>Changes</h2>
<h3>New: Four Label Modes</h3>

Mode | Row 2 of each label | Menu item
-- | -- | --
Abbreviated Route Codes (default) | NCOAST 1, CHVST W 2, etc. | Labels — Abbreviated Route Codes
Driver Names | Assigned driver's name | Labels — Driver Names
Full Route Names | Full routeDescription value | Labels — Full Route Names
No Route Info | Blank | Labels — No Route Info


<h3>New: <code>abbreviateRoute()</code> + <code>formatRouteCode()</code></h3>
<p>All 25 known routes have a hand-designed code in a direct lookup table (<code>ROUTE_MAP</code>). Code format rules:</p>
<ul>
<li><strong>Standard:</strong> 6 alpha + optional integer — <code>NCOAST 1</code>, <code>LOGANH 2</code></li>
<li><strong>Directional:</strong> 5 alpha + direction letter + optional integer — <code>CHVST W 1</code>, <code>CHVST E 1</code></li>
<li><strong>No number</strong> when only one route exists with that base name — <code>AZALEA</code>, <code>NORMHT</code>, <code>GRNTVI</code>, <code>VOLNTR</code></li>
</ul>
<p>The alpha string and number are stored compact in the table (<code>CHVSTW1</code>) and formatted with spaces at display time by <code>formatRouteCode()</code>, so the table stays clean and any future entries automatically get correct spacing.</p>
<p>Adding a new route requires one line in <code>ROUTE_MAP</code>. If no entry exists for a route at runtime, the full route name prints as a fallback — nothing breaks silently.</p>
<h3>Bug Fixes</h3>
<ul>
<li><strong>Three duplicate <code>generateDeliveryLabels</code> functions</strong> removed — Gemini had appended new versions rather than replacing, and Apps Script was running the last one, which was broken</li>
<li><strong><code>formatContinuousLabelData</code></strong> was receiving <code>includeDriverNames</code> as a plain boolean instead of the full config object — route and abbreviated route modes were unreachable</li>
<li><strong><code>generateAllIndividualLabels</code></strong> label objects were missing <code>Route</code> and <code>AbbrevRoute</code> fields — only <code>Driver</code> was stored, so the formatter had nothing to work with for the other modes</li>
<li><strong><code>writeAndFormatContinuousLabels</code></strong> only merged row 2 and applied blue text when <code>includeDriverNames</code> was true — other modes got unmerged cells and black text</li>
<li><strong>Default config</strong> had <code>includeAbbreviatedRouteNames: true</code> hardcoded, so <code>generateWithoutDrivers()</code> was printing abbreviations instead of a blank row 2</li>
<li><strong><code>makeTheLabels</code></strong> (Distribution Day Tasks menu item 5) was wired in <code>onOpen</code> but the function did not exist — would have thrown a runtime error on every click</li>
</ul>
<h3>New: Page Stamp Label</h3>
<p>The bottom-right label (slot 30) on every Avery 6240 sheet is now reserved as a stamp label showing:</p>
<ul>
<li>Row 1: <code>Page N</code></li>
<li>Row 2: Generation timestamp (<code>yyyy/MM/dd HH:mm:ss</code>)</li>
</ul>
<p>Delivery labels are capped at 29 per sheet. If a label would fall in slot 30 it is bumped to the next sheet. Every sheet always has a stamp, even if the last sheet is mostly empty.</p>
<h3>Menu Cleanup</h3>
<ul>
<li>Label Generator menu items renamed — "Continuous" suffix dropped (it's always continuous now), wording simplified</li>
<li><strong><code>makeLabelsPDF</code></strong> previously had the label mode hardcoded as <code>generateWithRoutes()</code> with the others commented out — now prompts the user (1–4) when called from the menu, and accepts a <code>forcedMode</code> argument when called from <code>makeAllPDFs</code></li>
<li><strong><code>makeAllPDFs</code></strong> now passes <code>'abbreviated'</code> to <code>makeLabelsPDF</code> so the bulk run doesn't pause for a prompt</li>
<li>All menu item strings updated to match current function names</li>
</ul>
<hr>
<h2>Testing Checklist</h2>
<ul>
<li>[ ] All four label modes generate without error</li>
<li>[ ] Row 2 is blank in No Route Info mode (was broken before)</li>
<li>[ ] Blue text appears on row 2 in all non-blank modes</li>
<li>[ ] Row 2 is merged across both columns in all modes</li>
<li>[ ] Abbreviated codes display with spaces: <code>CHVST W 1</code> not <code>CHVSTW1</code></li>
<li>[ ] Stamp label appears in slot 30 of every sheet</li>
<li>[ ] Slot 30 on each sheet is never a delivery label</li>
<li>[ ] <code>makeTheLabels</code> (menu item 5) prompts and runs without error</li>
<li>[ ] <code>makeLabelsPDF</code> prompts for mode when run from menu</li>
<li>[ ] <code>makeAllPDFs</code> runs end-to-end without prompting for label mode</li>
<li>[ ] Print alignment on Avery 6240 stock is not affected</li>
</ul>
<hr>
<h2>Not In Scope</h2>
<ul>
<li>Map link generation (split to separate ticket)</li>
<li>README update (split to separate session)</li>
<li>Font size increase for abbreviated codes (reverted per print alignment feedback)</li>
</ul></body></html><!--EndFragment-->
</body>
</html>